### PR TITLE
DOC: add README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 audonnx
 =======
 
+|tests| |coverage| |docs| |python-versions| |license|
+
 **audonnx** deploys machine learning models stored in ONNX_ format.
 
 Machine learning models can be trained
@@ -24,3 +26,21 @@ Have a look at the installation_ and usage_ instructions.
 .. _Torch: https://pytorch.org/
 .. _installation: https://audeering.github.io/audonnx/install.html
 .. _usage: https://audeering.github.io/audonnx/usage.html
+
+
+.. badges images and links:
+.. |tests| image:: https://github.com/audeering/audonnx/workflows/Test/badge.svg
+    :target: https://github.com/audeering/audonnx/actions?query=workflow%3ATest
+    :alt: Test status
+.. |coverage| image:: https://codecov.io/gh/audeering/audonnx/branch/master/graph/badge.svg?token=UGxnVQiKGK
+    :target: https://codecov.io/gh/audeering/audonnx/
+    :alt: code coverage
+.. |docs| image:: https://img.shields.io/pypi/v/audonnx?label=docs
+    :target: https://audeering.github.io/audonnx/
+    :alt: audonnx's documentation
+.. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
+    :target: https://github.com/audeering/audonnx/blob/master/LICENSE
+    :alt: audonnx's MIT license
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/audonnx.svg
+    :target: https://pypi.org/project/audonnx/
+    :alt: audonnx's supported Python versions


### PR DESCRIPTION
This adds the usual badges to the README

![image](https://user-images.githubusercontent.com/173624/148542739-8639b7d4-4d4a-46c6-a6f3-624cabbab2d8.png)
