### PR TITLE
DOC: update usage example to new audinterface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,5 @@ jobs:
 
     - name: Test building documentation
       run: |
-        # python -m sphinx docs/ docs/_build/ -b html -W
+        python -m sphinx docs/ docs/_build/ -b html -W
       if: matrix.os == 'ubuntu-20.04'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -396,7 +396,7 @@ Create interface and process a file.
     interface = audinterface.Feature(
         feature_names=onnx_model_5.outputs['gender'].labels,
         process_func=onnx_model,
-        output_names='gender',
+        process_func_args={'output_names': 'gender'},
     )
     interface.process_file(file)
 


### PR DESCRIPTION
To avoid a deprecation warning when building the docs, this changes the usage example to

![image](https://user-images.githubusercontent.com/173624/148543523-ad4f2470-789e-484b-930f-9b77e0140edd.png)

It also re-enables building the docs in the test.