### PR TITLE
Fix author email address in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = audonnx
 author = Johannes Wagner, Hagen Wierstorf
-author_email = jwagner@audeering.com, @hwierstorf@audeering.com
+author_email = jwagner@audeering.com, hwierstorf@audeering.com
 url = https://github.com/audeering/audonnx/
 project_urls =
     Documentation = https://audeering.github.io/audonnx/


### PR DESCRIPTION
Publishing the package fails due to a wrong author email address: https://github.com/audeering/audonnx/runs/4758570898?check_suite_focus=true