### PR TITLE
CI: fix installing of publish doc dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
 
     - name: Install doc dependencies
       run: |


### PR DESCRIPTION
There was still an error when building the docs for publication: https://github.com/audeering/audonnx/runs/4758827388?check_suite_focus=true as the dependencies were not installed.