### PR TITLE
Argument to set device or providers

### DIFF
--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -18,6 +18,7 @@ def load(
         device_or_providers: typing.Union[
             str,
             typing.Sequence[str],
+            typing.Sequence[typing.Tuple[str, typing.Dict]],
         ] = 'cpu',
 ) -> Model:
     r"""Load model from folder.
@@ -39,7 +40,8 @@ def load(
             In legacy mode path to model ONNX file
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
-        device_or_providers: set device (``'cpu'`` or ``'cuda'``)
+        device_or_providers: set device 
+            (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a list of providers_
 
     Returns:

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -40,7 +40,7 @@ def load(
             In legacy mode path to model ONNX file
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
-        device_or_providers: set device 
+        device_or_providers: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a list of providers_
 

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -15,10 +15,10 @@ def load(
         model_file: str = 'model.yaml',
         labels_file: str = 'labels.yaml',
         transform_file: str = 'transform.yaml',
-        device_or_providers: typing.Union[
+        device: typing.Union[
             str,
-            typing.Sequence[str],
-            typing.Sequence[typing.Tuple[str, typing.Dict]],
+            typing.Tuple[str, typing.Dict],
+            typing.Sequence[typing.Union[str, typing.Tuple[str, typing.Dict]]],
         ] = 'cpu',
 ) -> Model:
     r"""Load model from folder.
@@ -40,9 +40,11 @@ def load(
             In legacy mode path to model ONNX file
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
-        device_or_providers: set device
+        device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
-            or a list of providers_
+            or a (list of) provider_
+
+    .. _provider: https://onnxruntime.ai/docs/execution-providers/
 
     Returns:
         model
@@ -80,7 +82,7 @@ def load(
             return audobject.from_yaml(
                 model_file_yaml,
                 override_args={
-                    'device_or_providers': device_or_providers,
+                    'device': device,
                 },
             )
     # LEGACY support
@@ -102,7 +104,7 @@ def load(
         model_file_onnx,
         labels=labels,
         transform=transform,
-        device_or_providers=device_or_providers,
+        device=device,
     )
 
     return model

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -40,7 +40,7 @@ def load(
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
         device_or_providers: set device (`'cpu'` or `'cuda'`)
-            or a list of providers_        
+            or a list of providers_
 
     Returns:
         model
@@ -75,8 +75,12 @@ def load(
         with open(model_file_yaml) as f:
             first_line = f.readline()
         if first_line.startswith('$audonnx'):  # ensure correct object
-            return audobject.from_yaml(model_file_yaml)
-
+            return audobject.from_yaml(
+                model_file_yaml,
+                override_args={
+                    'device_or_providers': device_or_providers,
+                },
+            )
     # LEGACY support
     # Otherwise create object from ONNX file
 

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -39,7 +39,7 @@ def load(
             In legacy mode path to model ONNX file
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
-        device_or_providers: set device (`'cpu'` or `'cuda'`)
+        device_or_providers: set device (``'cpu'`` or ``'cuda'``)
             or a list of providers_
 
     Returns:

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import oyaml as yaml
 
@@ -14,6 +15,10 @@ def load(
         model_file: str = 'model.yaml',
         labels_file: str = 'labels.yaml',
         transform_file: str = 'transform.yaml',
+        device_or_providers: typing.Union[
+            str,
+            typing.Sequence[str],
+        ] = 'cpu',
 ) -> Model:
     r"""Load model from folder.
 
@@ -34,6 +39,8 @@ def load(
             In legacy mode path to model ONNX file
         labels_file: YAML file with labels
         transform_file: YAML file with transformation
+        device_or_providers: set device (`'cpu'` or `'cuda'`)
+            or a list of providers_        
 
     Returns:
         model
@@ -89,6 +96,7 @@ def load(
         model_file_onnx,
         labels=labels,
         transform=transform,
+        device_or_providers=device_or_providers,
     )
 
     return model

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -45,7 +45,7 @@ class Model(audobject.Object):
         path: path to model file
         labels: list of labels or dictionary with labels
         transform: callable object or a dictionary of callable objects
-        device_or_providers: set device (`'cpu'` or `'cuda'`)
+        device_or_providers: set device (``'cpu'`` or ``'cuda'``)
             or a list of providers_
 
     .. _providers: https://onnxruntime.ai/docs/execution-providers/

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -206,8 +206,8 @@ class Model(audobject.Object):
             ...     signal,
             ...     sampling_rate,
             ...     output_names='gender',
-            ... ).round(2)
-            array([-195.1 ,   73.28], dtype=float32)
+            ... ).round(1)
+            array([-195.1,   73.3], dtype=float32)
 
         """
         if output_names is None:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-opensmile >=2.3.0
+opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 onnx

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -415,11 +415,7 @@ Then select CUDA device when loading the model:
     import os
     import audonnx
 
-    model = audonnx.load(              # load model
-        ...,
-        device_or_providers='cuda:2',  # set cuda device
-    )
-    model(...)                         # runs on GPU
+    model = audonnx.load(..., device='cuda:2')
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -419,8 +419,11 @@ we can do:
     import audonnx
 
     os.environ['CUDA_VISIBLE_DEVICES']='2'  # make cuda:2 default device
-    model = audonnx.load(...)               # load model
-    model(...)                              # run on cuda:2
+    model = audonnx.load(                   # load model
+        ...,
+        device_or_providers='cuda',         # set device to cuda
+    )
+    model(...)                              # runs on cuda:2
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -408,22 +408,18 @@ To run a model on the GPU install ``onnxruntime-gpu``.
 Note that the version has to fit the CUDA installation.
 We can get the information from this table_.
 
-By default,
-it uses the first GPU device it finds.
-To select a specific CUDA device,
-we can do:
+Then select CUDA device when loading the model:
 
 .. code-block:: python
 
     import os
     import audonnx
 
-    os.environ['CUDA_VISIBLE_DEVICES']='2'  # make cuda:2 default device
-    model = audonnx.load(                   # load model
+    model = audonnx.load(              # load model
         ...,
-        device_or_providers='cuda',         # set device to cuda
+        device_or_providers='cuda:2',  # set cuda device
     )
-    model(...)                              # runs on cuda:2
+    model(...)                         # runs on GPU
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -18,7 +18,7 @@ import audonnx
             {
                 'gender': ['female', 'male'],
             },
-            np.array([-195.1, 73.28], np.float32),
+            np.array([-195.1, 73.3], np.float32),
         ),
     ]
 )
@@ -43,7 +43,7 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
     )
     y = model(pytest.SIGNAL, pytest.SAMPLING_RATE)
 
-    np.testing.assert_almost_equal(y, expected, decimal=2)
+    np.testing.assert_almost_equal(y, expected, decimal=1)
     for key, values in labels.items():
         assert model.outputs[key].labels == labels[key]
 
@@ -55,7 +55,7 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
     )
     y = model(pytest.SIGNAL, pytest.SAMPLING_RATE)
 
-    np.testing.assert_almost_equal(y, expected, decimal=2)
+    np.testing.assert_almost_equal(y, expected, decimal=1)
     for key, values in labels.items():
         assert model.outputs[key].labels == labels[key]
 
@@ -82,6 +82,6 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
     model = audonnx.load(tmpdir)
     y = model(pytest.SIGNAL, pytest.SAMPLING_RATE)
 
-    np.testing.assert_almost_equal(y, expected, decimal=2)
+    np.testing.assert_almost_equal(y, expected, decimal=1)
     for key, values in labels.items():
         assert model.outputs[key].labels == labels[key]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -129,10 +129,6 @@ def test_call(model, output_names, expected):
         'CPUExecutionProvider',
         'cuda',
         'cuda:0',
-        pytest.param(
-            'cuda:999',  # invalid device ID
-            marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
         [
             'CUDAExecutionProvider',
             'CPUExecutionProvider',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -128,6 +128,7 @@ def test_call(model, output_names, expected):
         'cpu',
         'CPUExecutionProvider',
         'cuda',
+        'cuda:0',
         'CUDAExecutionProvider',
         [
             'CUDAExecutionProvider',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -123,6 +123,33 @@ def test_call(model, output_names, expected):
 
 
 @pytest.mark.parametrize(
+    'device_or_providers',
+    [
+        'cpu',
+        'CPUExecutionProvider',
+        'cuda',
+        'CUDAExecutionProvider',
+        [
+            'CUDAExecutionProvider',
+            'CPUExecutionProvider',
+        ]
+    ]
+)
+def test_device_or_providers(device_or_providers):
+    model = audonnx.Model(
+        pytest.MODEL_SINGLE_PATH,
+        transform=pytest.FEATURE,
+        device_or_providers=device_or_providers,
+    )
+    y = model(
+        pytest.SIGNAL,
+        pytest.SAMPLING_RATE,
+    )
+    expected = np.array([-195.1, 73.28], np.float32)
+    np.testing.assert_almost_equal(y, expected, decimal=2)
+
+
+@pytest.mark.parametrize(
     'path, labels, transform',
     [
         (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -129,6 +129,10 @@ def test_call(model, output_names, expected):
         'CPUExecutionProvider',
         'cuda',
         'cuda:0',
+        pytest.param(
+            'cuda:999',  # invalid device ID
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
         'CUDAExecutionProvider',
         [
             'CUDAExecutionProvider',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -133,7 +133,6 @@ def test_call(model, output_names, expected):
             'cuda:999',  # invalid device ID
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
-        'CUDAExecutionProvider',
         [
             'CUDAExecutionProvider',
             'CPUExecutionProvider',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -47,7 +47,7 @@ def test_labels(path, transform, labels, expected):
                 transform=pytest.FEATURE,
             ),
             None,
-            np.array([-195.1, 73.28], np.float32),
+            np.array([-195.1, 73.3], np.float32),
         ),
         (
             audonnx.Model(
@@ -55,7 +55,7 @@ def test_labels(path, transform, labels, expected):
                 transform=pytest.FEATURE,
             ),
             'gender',
-            np.array([-195.1, 73.28], np.float32),
+            np.array([-195.1, 73.3], np.float32),
         ),
         (
             audonnx.Model(
@@ -63,7 +63,7 @@ def test_labels(path, transform, labels, expected):
                 transform=pytest.FEATURE,
             ),
             ['gender'],
-            {'gender': np.array([-195.1, 73.28], np.float32)},
+            {'gender': np.array([-195.1, 73.3], np.float32)},
         ),
         (
             audonnx.Model(
@@ -117,9 +117,9 @@ def test_call(model, output_names, expected):
     )
     if isinstance(y, dict):
         for key, values in y.items():
-            np.testing.assert_almost_equal(y[key], expected[key], decimal=2)
+            np.testing.assert_almost_equal(y[key], expected[key], decimal=1)
     else:
-        np.testing.assert_almost_equal(y, expected, decimal=2)
+        np.testing.assert_almost_equal(y, expected, decimal=1)
 
 
 @pytest.mark.parametrize(
@@ -145,8 +145,8 @@ def test_device_or_providers(device_or_providers):
         pytest.SIGNAL,
         pytest.SAMPLING_RATE,
     )
-    expected = np.array([-195.1, 73.28], np.float32)
-    np.testing.assert_almost_equal(y, expected, decimal=2)
+    expected = np.array([-195.1, 73.3], np.float32)
+    np.testing.assert_almost_equal(y, expected, decimal=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -123,23 +123,38 @@ def test_call(model, output_names, expected):
 
 
 @pytest.mark.parametrize(
-    'device_or_providers',
+    'device',
     [
         'cpu',
         'CPUExecutionProvider',
         'cuda',
         'cuda:0',
+        (
+            'CUDAExecutionProvider',
+            {
+                'device_id': 0,
+            },
+        ),
         [
             'CUDAExecutionProvider',
             'CPUExecutionProvider',
-        ]
+        ],
+        [
+            (
+                'CUDAExecutionProvider',
+                {
+                    'device_id': 0,
+                },
+            ),
+            'CPUExecutionProvider',
+        ],
     ]
 )
-def test_device_or_providers(device_or_providers):
+def test_device_or_providers(device):
     model = audonnx.Model(
         pytest.MODEL_SINGLE_PATH,
         transform=pytest.FEATURE,
-        device_or_providers=device_or_providers,
+        device=device,
     )
     y = model(
         pytest.SIGNAL,


### PR DESCRIPTION
Since ORT 1.9 it is required to explicitly set the providers parameter when instantiating InferenceSession.

This adds the argument `device_or_providers`, which can be set to a device (e.g. `cuda:2`) or a list of [providers](https://onnxruntime.ai/docs/execution-providers/).

![image](https://user-images.githubusercontent.com/10383417/152972764-0015f9c0-9eda-4602-b5a2-8754d87bfe9c.png)

![image](https://user-images.githubusercontent.com/10383417/152972798-19701f7e-0459-4954-adf0-9bfc47376192.png)

![image](https://user-images.githubusercontent.com/10383417/152972849-bd84fa1f-292f-4a38-89ee-211fc4212b61.png)
