### PR TITLE
Update dependency to onnxruntime

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     audeer >=1.14.0
     audobject >=0.6.1
-    onnxruntime >=1.1.0
+    onnxruntime >=1.8.0
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     audeer >=1.14.0
     audobject >=0.6.1
-    onnxruntime
+    onnxruntime >=1.8.0
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     audeer >=1.14.0
     audobject >=0.6.1
-    onnxruntime >=1.8.0
+    onnxruntime >=1.1.0
 setup_requires =
     setuptools_scm
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-onnxruntime >=1.8.0
 opensmile >=2.3.0
 torch
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+onnxruntime >=1.8.0
 opensmile >=2.3.0
 torch
 pytest


### PR DESCRIPTION
With the introduction of `device` in #8, we now require  `onnxruntime>=1.1.0` for the package and  `onnxruntime>=1.8.0` for the tests. 