### PR TITLE
Input/output node shape: replace dynamic axis with -1

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -311,5 +311,5 @@ def _device_to_providers(
 def _shape(
         shape: typing.List[typing.Union[int, str]],
 ) -> typing.List[int]:
-    r"""Replace 'time' with -1."""
+    r"""Replace dynamic axis names with -1."""
     return [-1 if isinstance(x, str) else x for x in shape]

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -312,4 +312,4 @@ def _shape(
         shape: typing.List[typing.Union[int, str]],
 ) -> typing.List[int]:
     r"""Replace 'time' with -1."""
-    return [-1 if x == 'time' else x for x in shape]
+    return [-1 if isinstance(x, str) else x for x in shape]

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -125,8 +125,9 @@ class Model(audobject.Object):
         r"""Input nodes"""
         for input in inputs:
             trans = transform[input.name] if input.name in transform else None
+            shape = _shape(input.shape)
             self.inputs[str(input.name)] = InputNode(
-                [-1 if x == 'time' else x for x in input.shape],
+                shape,
                 input.type,
                 trans,
             )
@@ -135,6 +136,7 @@ class Model(audobject.Object):
         r"""Output nodes"""
         for output in outputs:
             shape = output.shape or [1]
+            shape = _shape(shape)
             dim = shape[-1]
             if output.name in labels:
                 lab = labels[output.name]
@@ -304,3 +306,10 @@ def _device_to_providers(
     else:
         providers = device
     return providers
+
+
+def _shape(
+        shape: typing.List[typing.Union[int, str]],
+) -> typing.List[int]:
+    r"""Replace 'time' with -1."""
+    return [-1 if x == 'time' else x for x in shape]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,34 @@ torch.onnx.export(
 )
 
 
+# create model with dynamic input / output node
+
+class TorchModelDynamic(torch.nn.Module):
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor):
+        return x
+
+
+pytest.MODEL_DYNAMIC_PATH = os.path.join(pytest.TMP, 'dynamic.onnx')
+torch.onnx.export(
+    TorchModelDynamic(),
+    torch.randn(pytest.FEATURE_SHAPE),
+    pytest.MODEL_DYNAMIC_PATH,
+    input_names=['input'],
+    output_names=['output'],
+    dynamic_axes={
+        'input': {1: 'time'},
+        'output': {1: 'time'},
+    },
+    opset_version=12,
+)
+
+
 # clean up
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,8 +151,8 @@ torch.onnx.export(
     input_names=['input'],
     output_names=['output'],
     dynamic_axes={
-        'input': {1: 'time'},
-        'output': {1: 'time'},
+        'input': {1: 'dynamic'},
+        'output': {1: 'dynamic'},
     },
     opset_version=12,
 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -214,7 +214,7 @@ def test_nodes(path, labels, transform):
     for idx, (name, node) in enumerate(model.inputs.items()):
         assert name == inputs[idx].name
         assert node.shape == [
-            -1 if x == 'time' else x for x in inputs[idx].shape
+            -1 if isinstance(x, str) else x for x in inputs[idx].shape
         ]
         assert node.dtype == inputs[idx].type
 
@@ -222,7 +222,7 @@ def test_nodes(path, labels, transform):
         assert name == outputs[idx].name
         if outputs[idx].shape:
             assert node.shape == [
-                -1 if x == 'time' else x for x in outputs[idx].shape
+                -1 if isinstance(x, str) else x for x in outputs[idx].shape
             ]
         else:
             assert node.shape == [1]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -173,6 +173,11 @@ def test_device_or_providers(device):
             pytest.FEATURE,
         ),
         (
+            pytest.MODEL_DYNAMIC_PATH,
+            None,
+            pytest.FEATURE,
+        ),
+        (
             pytest.MODEL_MULTI_PATH,
             {
                 'gender': ['female', 'male'],
@@ -216,7 +221,9 @@ def test_nodes(path, labels, transform):
     for idx, (name, node) in enumerate(model.outputs.items()):
         assert name == outputs[idx].name
         if outputs[idx].shape:
-            assert node.shape == outputs[idx].shape
+            assert node.shape == [
+                -1 if x == 'time' else x for x in outputs[idx].shape
+            ]
         else:
             assert node.shape == [1]
         assert node.dtype == outputs[idx].type


### PR DESCRIPTION
Closes #17 

In ONNX format axis with a dynamic size are represented by a string. This is not convenient as we cannot directly use it to e.g. reshape an input array to match the expected shape. We therefore replace the string with -1 in the node classes of `audonnx`.