### PR TITLE
Support output nodes where last dimension is dynamic

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -28,9 +28,13 @@ class Model(audobject.Object):
     Use dictionary to assign transform objects to specific nodes
     if model has multiple input nodes.
 
-    For output nodes an optional list of labels can be given,
-    where each label corresponds to a dimension in the output,
-    i.e. the number of labels must match the dimension of the output node.
+    For output nodes an optional list of labels can be given
+    to assign names to the last non-dynamic dimension.
+    E.g. if the shape of the output node is
+    ``(1, 3, -1)``
+    three labels can be assigned to the second dimension.
+    By default,
+    labels are generated from the name of the node.
     Use dictionary to assign labels to specific nodes
     if model has multiple output nodes.
 
@@ -137,7 +141,7 @@ class Model(audobject.Object):
         for output in outputs:
             shape = output.shape or [1]
             shape = _shape(shape)
-            dim = shape[-1]
+            dim = _last_static_dim(shape)
             if output.name in labels:
                 lab = labels[output.name]
                 if len(lab) != dim:
@@ -308,8 +312,16 @@ def _device_to_providers(
     return providers
 
 
+def _last_static_dim(
+        shape: typing.List[int],
+) -> int:
+    r"""Return index of last static dimension."""
+    shape = list(filter((-1).__ne__, shape))
+    return shape[-1] if len(shape) else 0
+
+
 def _shape(
         shape: typing.List[typing.Union[int, str]],
 ) -> typing.List[int]:
-    r"""Replace dynamic axis names with -1."""
+    r"""Replace dynamic dimension names with -1."""
     return [-1 if isinstance(x, str) else x for x in shape]

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -156,7 +156,8 @@ class Model(audobject.Object):
             elif dim_size == 1:
                 lab = [output.name]
             else:
-                lab = [f'{output.name}-{idx}' for idx in range(dim_size)]
+                lab = [f'{output.name}-{idx}'
+                       for idx in range(dim_size)]
             self.outputs[output.name] = OutputNode(
                 shape,
                 output.type,
@@ -315,7 +316,7 @@ def _device_to_providers(
 def _last_static_dim_size(
         shape: typing.List[int],
 ) -> int:
-    r"""Return index of last static dimension."""
+    r"""Return size of last static dimension."""
     shape = list(filter((-1).__ne__, shape))
     return shape[-1] if len(shape) else 0
 

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -141,22 +141,22 @@ class Model(audobject.Object):
         for output in outputs:
             shape = output.shape or [1]
             shape = _shape(shape)
-            dim = _last_static_dim(shape)
+            dim_size = _last_static_dim_size(shape)
             if output.name in labels:
                 lab = labels[output.name]
-                if len(lab) != dim:
+                if len(lab) != dim_size:
                     raise ValueError(
                         f"Cannot assign "
                         f"{len(lab)} "
-                        f"labels to output "
+                        f"labels to output node "
                         f"'{output.name}' "
-                        f"with dimension "
-                        f"{dim}."
+                        f"when last non-dynamic dimension has size "
+                        f"{dim_size}."
                     )
-            elif dim == 1:
+            elif dim_size == 1:
                 lab = [output.name]
             else:
-                lab = [f'{output.name}-{idx}' for idx in range(dim)]
+                lab = [f'{output.name}-{idx}' for idx in range(dim_size)]
             self.outputs[output.name] = OutputNode(
                 shape,
                 output.type,
@@ -312,7 +312,7 @@ def _device_to_providers(
     return providers
 
 
-def _last_static_dim(
+def _last_static_dim_size(
         shape: typing.List[int],
 ) -> int:
     r"""Return index of last static dimension."""

--- a/audonnx/core/node.py
+++ b/audonnx/core/node.py
@@ -59,7 +59,7 @@ class OutputNode:
     Args:
         shape: list with dimensions
         dtype: data type
-        labels: list with names of output dimensions
+        labels: list with names of last non-dynamic output dimension
 
     """
     def __init__(
@@ -75,7 +75,7 @@ class OutputNode:
         r"""Data type of node"""
 
         self.labels = labels
-        r"""Names of output dimensions."""
+        r"""Labels of last non-dynamic output dimension."""
 
     def _dict(self) -> typing.Dict:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 onnx
+protobuf <=3.20.1  # avoid TypeError: Descriptors cannot not be created directly
 torch
 sphinx
 sphinx-audeering-theme >=1.0.14

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -178,6 +178,11 @@ def test_device_or_providers(device):
             pytest.FEATURE,
         ),
         (
+            pytest.MODEL_DYNAMIC_PATH,
+            pytest.FEATURE.feature_names,
+            pytest.FEATURE,
+        ),
+        (
             pytest.MODEL_MULTI_PATH,
             {
                 'gender': ['female', 'male'],


### PR DESCRIPTION
Closes #20 

Labels are now assigned to the last non-dynamic dimension. The docstring has been adapted and is also more precise now:

![image](https://user-images.githubusercontent.com/10383417/171946851-1056709b-d6f2-4f2d-afa1-7ff965355657.png)

![image](https://user-images.githubusercontent.com/10383417/171946918-e969b00e-3c9c-497e-941f-cc565679e314.png)

Example from #20 now works as expected:

```python
class TorchModel(torch.nn.Module):

    def __init__(
        self,
    ):
        super().__init__()

    def forward(self, x: torch.Tensor):
        return torch.cat([x, x])


torch_model = TorchModel()

input = torch.randn((1, 10))  # batch, time, feature
output = torch_model(input)
print(output)

onnx_path = 'model.onnx'
torch.onnx.export(
    torch_model,
    input,
    onnx_path,
    input_names=['input'],
    output_names=['output'],
    dynamic_axes={
        'input': {1: 'time'},
        'output': {1: 'time'},
    },
    opset_version=12,
)

audonnx.Model(
    onnx_path,
    labels=['left', 'right'],
)
```
```
Input:
  input:
    shape: [1, -1]
    dtype: tensor(float)
    transform: None
Output:
  output:
    shape: [2, -1]
    dtype: tensor(float)
    labels: [left, right]
```

If a wrong number of labels is provided, the error message is also more explicit now:

```python
audonnx.Model(
    onnx_path,
    labels=['left', 'right', 'bad'],
)
```
```
ValueError: Cannot assign 3 labels to output node 'output' when last non-dynamic dimension has size 2.
```
