### PR TITLE
Init model from ONNX object

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -301,7 +301,7 @@ class Model(audobject.Object):
             raise ValueError(f"Model path {path} does not end on '.yaml'")
 
         if self.path is None:
-            # if model was laod from a byte stream,
+            # if model was loaded from a byte stream,
             # we have to save it first
             self.path = audeer.replace_file_extension(path, 'onnx')
             audeer.mkdir(os.path.dirname(path))

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -47,7 +47,7 @@ class Model(audobject.Object):
     to see all available methods.
 
     Args:
-        path: ONNX object or path to model file
+        path: ONNX model object or path to ONNX file
         labels: list of labels or dictionary with labels
         transform: callable object or a dictionary of callable objects
         device: set device

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -47,7 +47,7 @@ class Model(audobject.Object):
     to see all available methods.
 
     Args:
-        path: ONNX model or path to model file
+        path: ONNX object or path to model file
         labels: list of labels or dictionary with labels
         transform: callable object or a dictionary of callable objects
         device: set device
@@ -55,22 +55,37 @@ class Model(audobject.Object):
             or a (list of) provider(s)_
 
     Example:
-        >>> import audonnx.testing
-        >>> model = audonnx.testing.create_model([[1, -1]])
+        >>> import audiofile
+        >>> import opensmile
+        >>> transform = opensmile.Smile(
+        ...    opensmile.FeatureSet.GeMAPSv01b,
+        ...    opensmile.FeatureLevel.LowLevelDescriptors,
+        ... )
+        >>> path = os.path.join('tests', 'model.onnx')
+        >>> model = Model(
+        ...     path,
+        ...     labels=['female', 'male'],
+        ...     transform=transform,
+        ... )
         >>> model
         Input:
-          input-0:
-            shape: [1, -1]
+          feature:
+            shape: [18, -1]
             dtype: tensor(float)
-            transform: audonnx.core.function.Function
+            transform: opensmile.core.smile.Smile
         Output:
-          output-0:
-            shape: [1, -1]
+          gender:
+            shape: [2]
             dtype: tensor(float)
-            labels: [output-0]
-        >>> signal = np.zeros([1, 5], dtype=np.float32)
-        >>> model(signal, 8000)
-        array([[0., 0., 0., 0., 0.]], dtype=float32)
+            labels: [female, male]
+        >>> path = os.path.join('tests', 'test.wav')
+        >>> signal, sampling_rate = audiofile.read(path)
+        >>> model(
+        ...     signal,
+        ...     sampling_rate,
+        ...     output_names='gender',
+        ... ).round(1)
+        array([-195.1,   73.3], dtype=float32)
 
     .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
 
@@ -217,20 +232,6 @@ class Model(audobject.Object):
 
         Returns:
             model output
-
-        Examples:
-            >>> import audiofile
-            >>> audio_path = os.path.join('tests', 'test.wav')
-            >>> signal, sampling_rate = audiofile.read(audio_path)
-            >>> model_path = os.path.join('tests', 'model.yaml')
-            >>> import audobject
-            >>> model = audobject.from_yaml(model_path)
-            >>> model(
-            ...     signal,
-            ...     sampling_rate,
-            ...     output_names='gender',
-            ... ).round(1)
-            array([-195.1,   73.3], dtype=float32)
 
         """
         if output_names is None:

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -285,7 +285,8 @@ class Model(audobject.Object):
         r"""Save model to YAML file.
 
         If ONNX model was loaded from a byte stream,
-        it will be saved under the same path
+        it will be saved in addition to the YAML file
+        under the same path
         with file extension ``.onnx``.
 
         Args:

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -54,6 +54,24 @@ class Model(audobject.Object):
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a (list of) provider(s)_
 
+    Example:
+        >>> import audonnx.testing
+        >>> model = audonnx.testing.create_model([[1, -1]])
+        >>> model
+        Input:
+          input-0:
+            shape: [1, -1]
+            dtype: tensor(float)
+            transform: audonnx.core.function.Function
+        Output:
+          output-0:
+            shape: [1, -1]
+            dtype: tensor(float)
+            labels: [output-0]
+        >>> signal = np.zeros([1, 5], dtype=np.float32)
+        >>> model(signal, 8000)
+        array([[0., 0., 0., 0., 0.]], dtype=float32)
+
     .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
 
     """

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -9,7 +9,6 @@ import audonnx
 
 
 def create_model(
-        root: str,
         shapes: typing.Sequence[typing.Sequence[int]],
         *,
         value: float = 0.,
@@ -28,7 +27,6 @@ def create_model(
     one dynamic axis is allowed.
 
     Args:
-        root: folder where model is stored
         shapes: list with shapes defining the output nodes of the model.
             The model will have the same number of input nodes,
             copying the shapes from the output nodes
@@ -41,7 +39,7 @@ def create_model(
 
     Example:
         >>> shapes = [[3], [1, -1, 2]]
-        >>> model = audonnx.testing.create_model('test', shapes)
+        >>> model = audonnx.testing.create_model(shapes)
         >>> model
         Input:
           input-0:
@@ -72,13 +70,10 @@ def create_model(
     .. _`supported data types`: https://onnxruntime.ai/docs/reference/operators/custom-python-operator.html#supported-data-types
 
     """  # noqa: E501
-    root = audeer.mkdir(root)
-    path = audeer.path(root, 'model.onnx')
 
     # create graph
 
     graph = _identity_graph(shapes, dtype, opset_version)
-    onnx.save(graph, path)
 
     # create transform objects
 
@@ -95,11 +90,9 @@ def create_model(
     # create model
 
     model = audonnx.Model(
-        path,
+        graph,
         transform=transform,
     )
-    path = audeer.path(root, 'model.yaml')
-    model.to_yaml(path)
 
     return model
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,8 @@
+import audeer
 import numpy as np
 import pytest
 
-import audonnx
+import audonnx.testing
 
 
 @pytest.mark.parametrize(
@@ -162,6 +163,31 @@ def test_device_or_providers(device):
     )
     expected = np.array([-195.1, 73.3], np.float32)
     np.testing.assert_almost_equal(y, expected, decimal=1)
+
+
+def test_init(tmpdir):
+
+    # create model from ONNX object
+
+    model = audonnx.testing.create_model([[1, -1]])
+    assert model.path is None
+
+    # save model to YAML
+
+    yaml_path = audeer.path(tmpdir, 'model.yaml')
+    model.to_yaml(yaml_path)
+    onnx_path = audeer.replace_file_extension(yaml_path, 'onnx')
+    assert model.path == onnx_path
+
+    # create model from ONNX file
+
+    model_2 = audonnx.Model(onnx_path)
+    assert model_2.path == onnx_path
+
+    # load from YAML
+
+    model_3 = audonnx.load(tmpdir)
+    assert model_3.path == onnx_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds option to Initialize `Model` from ONNX object and removes `root` argument from `testing.create_model()`.

![image](https://user-images.githubusercontent.com/10383417/172798065-796526af-4a72-4f0f-b9a6-81509f7ae9ad.png)

