### PR TITLE
TST: refactor using audonnx.testing

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -15,6 +15,7 @@ from audonnx.core.node import (
     OutputNode,
 )
 from audonnx.core.typing import (
+    Device,
     Labels,
     Transform,
 )
@@ -108,12 +109,7 @@ class Model(audobject.Object):
             *,
             labels: Labels = None,
             transform: Transform = None,
-            device: typing.Union[
-                str,
-                typing.Tuple[str, typing.Dict],
-                typing.Sequence[
-                    typing.Union[str, typing.Tuple[str, typing.Dict]]],
-            ] = 'cpu',
+            device: Device = 'cpu',
     ):
         # keep original arguments to store them
         # when object is serialized

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -48,7 +48,7 @@ class Model(audobject.Object):
     to see all available methods.
 
     Args:
-        path: ONNX model object or path to ONNX file
+        path: ONNX proto object or path to ONNX file
         labels: list of labels or dictionary with labels
         transform: callable object or a dictionary of callable objects
         device: set device

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -80,7 +80,7 @@ def create_model(
 
     # create graph
 
-    object = create_onnx_object(
+    object = create_model_proto(
         shapes,
         dtype=dtype,
         opset_version=opset_version,
@@ -109,13 +109,13 @@ def create_model(
     return model
 
 
-def create_onnx_object(
+def create_model_proto(
         shapes: typing.Sequence[typing.Sequence[int]],
         *,
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
 ) -> onnx.ModelProto:
-    r"""Create test ONNX object.
+    r"""Create test ONNX proto object.
 
     Creates an identity graph
     with input and output nodes
@@ -139,7 +139,7 @@ def create_onnx_object(
         ONNX object
 
     Example:
-        >>> create_onnx_object([[2]])
+        >>> create_model_proto([[2]])
         ir_version: 8
         producer_name: "test"
         graph {

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -126,6 +126,8 @@ def create_onnx_object(
     define a dynamic axis.
     Per node,
     one dynamic axis is allowed.
+    The identity graph can be used as ``path`` argument
+    of :class:`audonnx.Model`.
 
     Args:
         shapes: list with shapes defining the input and

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -128,9 +128,8 @@ def create_onnx_object(
     one dynamic axis is allowed.
 
     Args:
-        shapes: list with shapes defining the output nodes of the model.
-            The model will have the same number of input nodes,
-            copying the shapes from the output nodes
+        shapes: list with shapes defining the input and
+            output nodes of the graph
         dtype: data type, see `supported data types`_
         opset_version: opset version
 

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -135,6 +135,50 @@ def create_onnx_object(
         opset_version: opset version
 
     Returns:
+        ONNX object
+
+    Example:
+        >>> create_onnx_object([[2]])
+        ir_version: 8
+        producer_name: "test"
+        graph {
+          node {
+            input: "input-0"
+            output: "output-0"
+            op_type: "Identity"
+          }
+          name: "test"
+          input {
+            name: "input-0"
+            type {
+              tensor_type {
+                elem_type: 1
+                shape {
+                  dim {
+                    dim_value: 2
+                  }
+                }
+              }
+            }
+          }
+          output {
+            name: "output-0"
+            type {
+              tensor_type {
+                elem_type: 1
+                shape {
+                  dim {
+                    dim_value: 2
+                  }
+                }
+              }
+            }
+          }
+        }
+        opset_import {
+          version: 14
+        }
+        <BLANKLINE>
 
     """
 

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -31,9 +31,8 @@ def create_model(
     one dynamic axis is allowed.
 
     Args:
-        shapes: list with shapes defining the output nodes of the model.
-            The model will have the same number of input nodes,
-            copying the shapes from the output nodes
+        shapes: list with shapes defining the identical
+            input and output nodes of the model graph
         value: fill value
         dtype: data type, see `supported data types`_
         opset_version: opset version
@@ -130,8 +129,8 @@ def create_model_proto(
     of :class:`audonnx.Model`.
 
     Args:
-        shapes: list with shapes defining the input and
-            output nodes of the graph
+        shapes: list with shapes defining the identical
+            input and output nodes of the model graph
         dtype: data type, see `supported data types`_
         opset_version: opset version
 

--- a/audonnx/core/typing.py
+++ b/audonnx/core/typing.py
@@ -4,6 +4,14 @@ import typing
 import numpy as np
 
 
+Device = typing.Union[
+    str,
+    typing.Tuple[str, typing.Dict],
+    typing.Sequence[
+        typing.Union[str, typing.Tuple[str, typing.Dict]]],
+]
+
+
 Labels = typing.Union[
     typing.Sequence[str],
     typing.Dict[

--- a/audonnx/testing/__init__.py
+++ b/audonnx/testing/__init__.py
@@ -1,4 +1,4 @@
 from audonnx.core.testing import (
     create_model,
-    create_onnx_object,
+    create_model_proto,
 )

--- a/audonnx/testing/__init__.py
+++ b/audonnx/testing/__init__.py
@@ -1,1 +1,4 @@
-from audonnx.core.testing import create_model
+from audonnx.core.testing import (
+    create_model,
+    create_onnx_object,
+)

--- a/docs/api-testing.rst
+++ b/docs/api-testing.rst
@@ -14,13 +14,13 @@ In order to use it you first have to import it explicitly:
     import audonnx.testing
 
 
-create_graph
-------------
-
-.. autofunction:: create_graph
-
-
 create_model
 ------------
 
 .. autofunction:: create_model
+
+
+create_onnx_object
+------------------
+
+.. autofunction:: create_onnx_object

--- a/docs/api-testing.rst
+++ b/docs/api-testing.rst
@@ -20,7 +20,7 @@ create_model
 .. autofunction:: create_model
 
 
-create_onnx_object
+create_model_proto
 ------------------
 
-.. autofunction:: create_onnx_object
+.. autofunction:: create_model_proto

--- a/docs/api-testing.rst
+++ b/docs/api-testing.rst
@@ -14,6 +14,12 @@ In order to use it you first have to import it explicitly:
     import audonnx.testing
 
 
+create_graph
+------------
+
+.. autofunction:: create_graph
+
+
 create_model
 ------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     audobject >=0.7.1
     onnxruntime >=1.8.0
 setup_requires =
-    setuptools_scm
+    setuptools_scm != 7.0.0  # https://github.com/pypa/setuptools_scm/issues/718
 
 [tool:pytest]
 addopts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,13 @@
 import glob
 import os
-import random
 import shutil
 
-import numpy as np
-import opensmile
-
 import pytest
-import torch
 
 import audeer
 import audiofile
 import audobject
+import opensmile
 
 
 pytest.ROOT = audeer.safe_path(
@@ -38,44 +34,6 @@ pytest.FEATURE_SHAPE = pytest.FEATURE(
     pytest.SIGNAL,
     pytest.SAMPLING_RATE,
 ).shape[1:]
-
-# fix seed
-
-seed = 1234
-torch.backends.cudnn.deterministic = True
-torch.manual_seed(seed)
-torch.cuda.manual_seed_all(seed)
-np.random.seed(seed)
-random.seed(seed)
-
-
-# create model with single output node
-
-class TorchModel(torch.nn.Module):
-
-    def __init__(
-        self,
-    ):
-        super().__init__()
-        self.hidden = torch.nn.Linear(pytest.FEATURE_SHAPE[0], 8)
-        self.out = torch.nn.Linear(8, 2)
-
-    def forward(self, x: torch.Tensor):
-        y = self.hidden(x.mean(dim=-1))
-        y = self.out(y)
-        return y.squeeze()
-
-
-pytest.MODEL_PATH = os.path.join(pytest.TMP, 'model.onnx')
-torch.onnx.export(
-    TorchModel(),
-    torch.randn(pytest.FEATURE_SHAPE),
-    pytest.MODEL_PATH,
-    input_names=['feature'],
-    output_names=['gender'],
-    dynamic_axes={'feature': {1: 'time'}},
-    opset_version=12,
-)
 
 
 # clean up

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,6 @@ opensmile >=2.3.0
 # Avoid pip error on Python 3.7,
 # compare https://github.com/audeering/audonnx/runs/5737150095
 audobject >=0.7.1
-torch
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -34,7 +34,7 @@ def uninstall(
 def test(tmpdir):
 
     model = audonnx.Model(
-        pytest.MODEL_SINGLE_PATH,
+        pytest.MODEL_PATH,
         transform=pytest.FEATURE,
     )
     model_path = os.path.join(tmpdir, 'model.yaml')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -33,7 +33,7 @@ def uninstall(
 
 def test(tmpdir):
 
-    object = audonnx.testing.create_onnx_object([pytest.FEATURE_SHAPE])
+    object = audonnx.testing.create_model_proto([pytest.FEATURE_SHAPE])
     model = audonnx.Model(
         object,
         transform=pytest.FEATURE,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-import audonnx
+import audonnx.testing
 
 
 def uninstall(
@@ -33,8 +33,9 @@ def uninstall(
 
 def test(tmpdir):
 
+    object = audonnx.testing.create_onnx_object([pytest.FEATURE_SHAPE])
     model = audonnx.Model(
-        pytest.MODEL_PATH,
+        object,
         transform=pytest.FEATURE,
     )
     model_path = os.path.join(tmpdir, 'model.yaml')

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -13,7 +13,7 @@ import audonnx
     'path, transform, labels, expected',
     [
         (
-            pytest.MODEL_SINGLE_PATH,
+            pytest.MODEL_PATH,
             pytest.FEATURE,
             {
                 'gender': ['female', 'male'],

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -20,7 +20,7 @@ def min_max(x, sr):
     'object, transform, labels, expected',
     [
         (
-            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.testing.create_model_proto([[2]]),
             audonnx.Function(min_max),
             {'output-0': ['min', 'max']},
             min_max(pytest.SIGNAL, pytest.SAMPLING_RATE),

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,30 +1,38 @@
 import os
 
-import audeer
 import numpy as np
+import onnx
 import oyaml as yaml
 import pytest
 
+import audeer
+
 import audobject
-import audonnx
+import audonnx.testing
+
+
+def min_max(x, sr):
+    import numpy as np
+    return np.array([x.min(), x.max()], np.float32)
 
 
 @pytest.mark.parametrize(
-    'path, transform, labels, expected',
+    'object, transform, labels, expected',
     [
         (
-            pytest.MODEL_PATH,
-            pytest.FEATURE,
-            {
-                'gender': ['female', 'male'],
-            },
-            np.array([-195.1, 73.3], np.float32),
+            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.Function(min_max),
+            {'output-0': ['min', 'max']},
+            min_max(pytest.SIGNAL, pytest.SAMPLING_RATE),
         ),
     ]
 )
-def test_load_legacy(tmpdir, path, transform, labels, expected):
+def test_load_legacy(tmpdir, object, transform, labels, expected):
 
-    root = os.path.dirname(path)
+    root = tmpdir
+
+    onnx_path = os.path.join(root, 'model.onnx')
+    onnx.save(object, onnx_path)
 
     # create from onnx
 
@@ -37,7 +45,7 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
 
     model = audonnx.load(
         root,
-        model_file=os.path.basename(path),
+        model_file=os.path.basename(onnx_path),
         transform_file=os.path.basename(transform_path),
         labels_file=os.path.basename(labels_path),
     )
@@ -51,7 +59,7 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
 
     model = audonnx.load(
         root,
-        model_file=audeer.replace_file_extension(path, 'yaml'),
+        model_file=audeer.replace_file_extension(onnx_path, 'yaml'),
     )
     y = model(pytest.SIGNAL, pytest.SAMPLING_RATE)
 
@@ -65,7 +73,7 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
     audobject.Object().to_yaml(model_path)
     model = audonnx.load(
         root,
-        model_file=os.path.basename(path),
+        model_file=os.path.basename(onnx_path),
     )
 
     # file extension does not end on '.yaml'
@@ -82,6 +90,6 @@ def test_load_legacy(tmpdir, path, transform, labels, expected):
     model = audonnx.load(tmpdir)
     y = model(pytest.SIGNAL, pytest.SAMPLING_RATE)
 
-    np.testing.assert_almost_equal(y, expected, decimal=1)
+    np.testing.assert_equal(y, expected)
     for key, values in labels.items():
         assert model.outputs[key].labels == labels[key]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,7 @@ def min_max(x, sr):
     'model, output_names, expected',
     [
         (
-            audonnx.Model(audonnx.testing.create_onnx_object([[1, -1]])),
+            audonnx.Model(audonnx.testing.create_model_proto([[1, -1]])),
             None,
             pytest.SIGNAL,
         ),
@@ -126,7 +126,7 @@ def test_init(tmpdir):
 
     # create model from ONNX object
 
-    object = audonnx.testing.create_onnx_object([[1, -1]])
+    object = audonnx.testing.create_model_proto([[1, -1]])
     model = audonnx.Model(object)
     assert model.path is None
 
@@ -152,25 +152,25 @@ def test_init(tmpdir):
     'object, transform, labels, expected',
     [
         (
-            audonnx.testing.create_onnx_object([[1, -1]]),
+            audonnx.testing.create_model_proto([[1, -1]]),
             None,
             None,
             {'output-0': ['output-0']},
         ),
         (
-            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.testing.create_model_proto([[2]]),
             min_max,
             None,
             {'output-0': ['output-0-0', 'output-0-1']},
         ),
         (
-            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.testing.create_model_proto([[2]]),
             min_max,
             ['min', 'max'],
             {'output-0': ['min', 'max']},
         ),
         (
-            audonnx.testing.create_onnx_object([[1, -1], [2]]),
+            audonnx.testing.create_model_proto([[1, -1], [2]]),
             {'input-1': min_max},
             None,
             {
@@ -179,7 +179,7 @@ def test_init(tmpdir):
             },
         ),
         (
-            audonnx.testing.create_onnx_object([[1, -1], [2]]),
+            audonnx.testing.create_model_proto([[1, -1], [2]]),
             {'input-1': min_max},
             {'output-1': ['min', 'max']},
             {
@@ -188,7 +188,7 @@ def test_init(tmpdir):
             },
         ),
         pytest.param(
-            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.testing.create_model_proto([[2]]),
             min_max,
             ['too', 'many', 'labels'],
             None,
@@ -211,32 +211,32 @@ def test_labels(object, transform, labels, expected):
     'object, labels, transform',
     [
         (
-            audonnx.testing.create_onnx_object([[1, -1]]),
+            audonnx.testing.create_model_proto([[1, -1]]),
             None,
             None,
         ),
         (
-            audonnx.testing.create_onnx_object([[1, -1]]),
+            audonnx.testing.create_model_proto([[1, -1]]),
             ['signal'],
             None,
         ),
         (
-            audonnx.testing.create_onnx_object([[1, -1]]),
+            audonnx.testing.create_model_proto([[1, -1]]),
             ['signal'],
             lambda x, sr: x.T,
         ),
         (
-            audonnx.testing.create_onnx_object([[1, -1]]),
+            audonnx.testing.create_model_proto([[1, -1]]),
             ['signal'],
             lambda x, sr: np.atleast_3d(),
         ),
         (
-            audonnx.testing.create_onnx_object([[2]]),
+            audonnx.testing.create_model_proto([[2]]),
             ['min', 'max'],
             min_max,
         ),
         (
-            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            audonnx.testing.create_model_proto([[2], [1, -1]]),
             {
                 'input-0': ['min', 'max'],
                 'input-1': None,
@@ -247,13 +247,13 @@ def test_labels(object, transform, labels, expected):
             },
         ),
         pytest.param(  # plain list of labels but multiple output nodes
-            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            audonnx.testing.create_model_proto([[2], [1, -1]]),
             ['min', 'max'],
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(  # single transform object but multiple input nodes
-            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            audonnx.testing.create_model_proto([[2], [1, -1]]),
             None,
             min_max,
             marks=pytest.mark.xfail(raises=ValueError),
@@ -294,7 +294,7 @@ def test_nodes(object, labels, transform):
     [
         (
             audonnx.Model(
-                audonnx.testing.create_onnx_object([[1, -1]]),
+                audonnx.testing.create_model_proto([[1, -1]]),
             ), r'''Input:
   input-0:
     shape: [1, -1]
@@ -308,7 +308,7 @@ Output:
         ),
         (
             audonnx.Model(
-                audonnx.testing.create_onnx_object([[2]]),
+                audonnx.testing.create_model_proto([[2]]),
                 labels=['min', 'max'],
                 transform=lambda x, sr: [x.min(), x.max()],
             ), r'''Input:
@@ -324,7 +324,7 @@ Output:
         ),
         (
             audonnx.Model(
-                audonnx.testing.create_onnx_object([[2]]),
+                audonnx.testing.create_model_proto([[2]]),
                 labels=['min', 'max'],
                 transform=audonnx.Function(lambda x, sr: [x.min(), x.max()]),
             ), r'''Input:
@@ -340,7 +340,7 @@ Output:
         ),
         (
             audonnx.Model(
-                audonnx.testing.create_onnx_object([[2]]),
+                audonnx.testing.create_model_proto([[2]]),
                 labels=['min', 'max'],
                 transform=audonnx.Function(min_max),
             ), r'''Input:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -126,7 +126,8 @@ def test_init(tmpdir):
 
     # create model from ONNX object
 
-    model = audonnx.testing.create_model([[1, -1]])
+    object = audonnx.testing.create_onnx_object([[1, -1]])
+    model = audonnx.Model(object)
     assert model.path is None
 
     # save model to YAML

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,114 +1,75 @@
-import audeer
 import numpy as np
 import pytest
+
+import audeer
 
 import audonnx.testing
 
 
-@pytest.mark.parametrize(
-    'path, transform, labels, expected',
-    [
-        (
-            pytest.MODEL_SINGLE_PATH,
-            pytest.FEATURE,
-            None,
-            {'gender': ['gender-0', 'gender-1']},
-        ),
-        (
-            pytest.MODEL_SINGLE_PATH,
-            pytest.FEATURE,
-            ['female', 'male'],
-            {'gender': ['female', 'male']},
-        ),
-        pytest.param(
-            pytest.MODEL_SINGLE_PATH,
-            None,
-            ['too', 'many', 'labels'],
-            None,
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-    ]
-)
-def test_labels(path, transform, labels, expected):
-    model = audonnx.Model(
-        path,
-        labels=labels,
-        transform=transform,
-    )
-    for name, l in expected.items():
-        assert model.outputs[name].labels == l
+def min_max(x, sr):
+    return [x.min(), x.max()]
 
 
 @pytest.mark.parametrize(
     'model, output_names, expected',
     [
         (
-            audonnx.Model(
-                pytest.MODEL_SINGLE_PATH,
-                transform=pytest.FEATURE,
-            ),
+            audonnx.Model(audonnx.testing.create_onnx_object([[1, -1]])),
             None,
-            np.array([-195.1, 73.3], np.float32),
+            pytest.SIGNAL,
         ),
         (
-            audonnx.Model(
-                pytest.MODEL_SINGLE_PATH,
-                transform=pytest.FEATURE,
-            ),
-            'gender',
-            np.array([-195.1, 73.3], np.float32),
+            audonnx.testing.create_model([[2]]),
+            None,
+            np.array([0.0, 0.0], np.float32),
         ),
         (
-            audonnx.Model(
-                pytest.MODEL_SINGLE_PATH,
-                transform=pytest.FEATURE,
-            ),
-            ['gender'],
-            {'gender': np.array([-195.1, 73.3], np.float32)},
+            audonnx.testing.create_model([[2]]),
+            'output-0',
+            np.array([0.0, 0.0], np.float32),
         ),
         (
-            audonnx.Model(
-                pytest.MODEL_MULTI_PATH,
-                transform={
-                    'feature': pytest.FEATURE,
-                }
-            ),
+            audonnx.testing.create_model([[2]]),
+            ['output-0'],
+            {'output-0': np.array([0.0, 0.0], np.float32)},
+        ),
+        (
+            audonnx.testing.create_model([[2], [1, 3]]),
             None,
             {
-                'hidden': np.array([
-                    1.3299127e-01, 2.1280064e-01,
-                    -4.7600174e-01, -3.7167081e-01,
-                    6.6870685e+02, -4.2869656e+02,
-                    -4.5552551e+02, 8.6153650e+02,
-                ], np.float32),
-                'gender': np.array([224.83, -12.72], np.float32),
-                'confidence': np.array(-311.88, np.float32),
+                'output-0': np.array([0.0, 0.0], np.float32),
+                'output-1': np.array([[0.0, 0.0, 0.0]], np.float32),
             },
         ),
         (
-            audonnx.Model(
-                pytest.MODEL_MULTI_PATH,
-                transform={
-                    'feature': pytest.FEATURE,
-                }
-            ),
-            ['confidence', 'gender'],
+            audonnx.testing.create_model([[2], [1, 3]]),
+            'output-1',
+            np.array([[0.0, 0.0, 0.0]], np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[2], [1, 3]]),
+            ['output-1'],
             {
-                'confidence': np.array(-311.88, np.float32),
-                'gender': np.array([224.83, -12.72], np.float32),
+                'output-1': np.array([[0.0, 0.0, 0.0]], np.float32),
             },
         ),
         (
-            audonnx.Model(
-                pytest.MODEL_MULTI_PATH,
-                transform={
-                    'feature': pytest.FEATURE,
-                }
-            ),
-            'confidence',
-            np.array(-311.88, np.float32),
+            audonnx.testing.create_model([[2], [1, 3]]),
+            ['output-1', 'output-0'],
+            {
+                'output-1': np.array([[0.0, 0.0, 0.0]], np.float32),
+                'output-0': np.array([0.0, 0.0], np.float32),
+            },
         ),
-    ],
+        (
+            audonnx.testing.create_model([[2], [1, 3]]),
+            ['output-1', 'output-0', 'output-1'],
+            {
+                'output-1': np.array([[0.0, 0.0, 0.0]], np.float32),
+                'output-0': np.array([0.0, 0.0], np.float32),
+            },
+        ),
+    ]
 )
 def test_call(model, output_names, expected):
     y = model(
@@ -118,9 +79,9 @@ def test_call(model, output_names, expected):
     )
     if isinstance(y, dict):
         for key, values in y.items():
-            np.testing.assert_almost_equal(y[key], expected[key], decimal=1)
+            np.testing.assert_equal(y[key], expected[key])
     else:
-        np.testing.assert_almost_equal(y, expected, decimal=1)
+        np.testing.assert_equal(y, expected)
 
 
 @pytest.mark.parametrize(
@@ -152,17 +113,13 @@ def test_call(model, output_names, expected):
     ]
 )
 def test_device_or_providers(device):
-    model = audonnx.Model(
-        pytest.MODEL_SINGLE_PATH,
-        transform=pytest.FEATURE,
-        device=device,
-    )
+    model = audonnx.testing.create_model([[2]], device=device)
     y = model(
         pytest.SIGNAL,
         pytest.SAMPLING_RATE,
     )
-    expected = np.array([-195.1, 73.3], np.float32)
-    np.testing.assert_almost_equal(y, expected, decimal=1)
+    expected = np.array([0.0, 0.0], np.float32)
+    np.testing.assert_equal(y, expected)
 
 
 def test_init(tmpdir):
@@ -191,50 +148,121 @@ def test_init(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'path, labels, transform',
+    'object, transform, labels, expected',
     [
         (
-            pytest.MODEL_SINGLE_PATH,
+            audonnx.testing.create_onnx_object([[1, -1]]),
             None,
-            pytest.FEATURE,
-        ),
-        (
-            pytest.MODEL_DYNAMIC_PATH,
             None,
-            pytest.FEATURE,
+            {'output-0': ['output-0']},
         ),
         (
-            pytest.MODEL_DYNAMIC_PATH,
-            pytest.FEATURE.feature_names,
-            pytest.FEATURE,
+            audonnx.testing.create_onnx_object([[2]]),
+            min_max,
+            None,
+            {'output-0': ['output-0-0', 'output-0-1']},
         ),
         (
-            pytest.MODEL_MULTI_PATH,
+            audonnx.testing.create_onnx_object([[2]]),
+            min_max,
+            ['min', 'max'],
+            {'output-0': ['min', 'max']},
+        ),
+        (
+            audonnx.testing.create_onnx_object([[1, -1], [2]]),
+            {'input-1': min_max},
+            None,
             {
-                'gender': ['female', 'male'],
+                'output-0': ['output-0'],
+                'output-1': ['output-1-0', 'output-1-1'],
             },
-            {
-                'feature': pytest.FEATURE,
-            }
         ),
-        pytest.param(  # list of labels but multiple output nodes
-            pytest.MODEL_MULTI_PATH,
-            ['female', 'male'],
+        (
+            audonnx.testing.create_onnx_object([[1, -1], [2]]),
+            {'input-1': min_max},
+            {'output-1': ['min', 'max']},
+            {
+                'output-0': ['output-0'],
+                'output-1': ['min', 'max'],
+            },
+        ),
+        pytest.param(
+            audonnx.testing.create_onnx_object([[2]]),
+            min_max,
+            ['too', 'many', 'labels'],
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        pytest.param(  # transform object but multiple input nodes
-            pytest.MODEL_MULTI_PATH,
+    ]
+)
+def test_labels(object, transform, labels, expected):
+    model = audonnx.Model(
+        object,
+        labels=labels,
+        transform=transform,
+    )
+    assert list(expected) == list(model.outputs)
+    for name, l in expected.items():
+        assert model.outputs[name].labels == l
+
+
+@pytest.mark.parametrize(
+    'object, labels, transform',
+    [
+        (
+            audonnx.testing.create_onnx_object([[1, -1]]),
             None,
-            pytest.FEATURE,
+            None,
+        ),
+        (
+            audonnx.testing.create_onnx_object([[1, -1]]),
+            ['signal'],
+            None,
+        ),
+        (
+            audonnx.testing.create_onnx_object([[1, -1]]),
+            ['signal'],
+            lambda x, sr: x.T,
+        ),
+        (
+            audonnx.testing.create_onnx_object([[1, -1]]),
+            ['signal'],
+            lambda x, sr: np.atleast_3d(),
+        ),
+        (
+            audonnx.testing.create_onnx_object([[2]]),
+            ['min', 'max'],
+            min_max,
+        ),
+        (
+            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            {
+                'input-0': ['min', 'max'],
+                'input-1': None,
+            },
+            {
+                'output-0': min_max,
+                'output-1': None,
+            },
+        ),
+        pytest.param(  # plain list of labels but multiple output nodes
+            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            ['min', 'max'],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # single transform object but multiple input nodes
+            audonnx.testing.create_onnx_object([[2], [1, -1]]),
+            None,
+            min_max,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
     ],
 )
-def test_nodes(path, labels, transform):
+def test_nodes(object, labels, transform):
 
     model = audonnx.Model(
-        path,
+        object,
         labels=labels,
         transform=transform,
     )
@@ -245,7 +273,7 @@ def test_nodes(path, labels, transform):
     for idx, (name, node) in enumerate(model.inputs.items()):
         assert name == inputs[idx].name
         assert node.shape == [
-            -1 if isinstance(x, str) else x for x in inputs[idx].shape
+            -1 if not isinstance(x, int) else x for x in inputs[idx].shape
         ]
         assert node.dtype == inputs[idx].type
 
@@ -253,7 +281,7 @@ def test_nodes(path, labels, transform):
         assert name == outputs[idx].name
         if outputs[idx].shape:
             assert node.shape == [
-                -1 if isinstance(x, str) else x for x in outputs[idx].shape
+                -1 if not isinstance(x, int) else x for x in outputs[idx].shape
             ]
         else:
             assert node.shape == [1]
@@ -265,48 +293,104 @@ def test_nodes(path, labels, transform):
     [
         (
             audonnx.Model(
-                pytest.MODEL_SINGLE_PATH,
-                labels=['female', 'male'],
-                transform=pytest.FEATURE,
+                audonnx.testing.create_onnx_object([[1, -1]]),
             ), r'''Input:
-  feature:
-    shape: [18, -1]
-    dtype: tensor(float)
-    transform: opensmile.core.smile.Smile
-Output:
-  gender:
-    shape: [2]
-    dtype: tensor(float)
-    labels: [female, male]'''
-        ),
-        (
-            audonnx.Model(
-                pytest.MODEL_MULTI_PATH,
-                transform={
-                    'feature': pytest.FEATURE,
-                }
-            ), r'''Input:
-  signal:
+  input-0:
     shape: [1, -1]
     dtype: tensor(float)
     transform: None
-  feature:
-    shape: [18, -1]
-    dtype: tensor(float)
-    transform: opensmile.core.smile.Smile
 Output:
-  hidden:
-    shape: [8]
+  output-0:
+    shape: [1, -1]
     dtype: tensor(float)
-    labels: [hidden-0, hidden-1, hidden-2, (...), hidden-5, hidden-6, hidden-7]
-  gender:
+    labels: [output-0]'''
+        ),
+        (
+            audonnx.Model(
+                audonnx.testing.create_onnx_object([[2]]),
+                labels=['min', 'max'],
+                transform=lambda x, sr: [x.min(), x.max()],
+            ), r'''Input:
+  input-0:
     shape: [2]
     dtype: tensor(float)
-    labels: [gender-0, gender-1]
-  confidence:
-    shape: [1]
+    transform: builtins.function
+Output:
+  output-0:
+    shape: [2]
     dtype: tensor(float)
-    labels: [confidence]'''  # noqa
+    labels: [min, max]'''
+        ),
+        (
+            audonnx.Model(
+                audonnx.testing.create_onnx_object([[2]]),
+                labels=['min', 'max'],
+                transform=audonnx.Function(lambda x, sr: [x.min(), x.max()]),
+            ), r'''Input:
+  input-0:
+    shape: [2]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(<lambda>)
+Output:
+  output-0:
+    shape: [2]
+    dtype: tensor(float)
+    labels: [min, max]'''
+        ),
+        (
+            audonnx.Model(
+                audonnx.testing.create_onnx_object([[2]]),
+                labels=['min', 'max'],
+                transform=audonnx.Function(min_max),
+            ), r'''Input:
+  input-0:
+    shape: [2]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(min_max)
+Output:
+  output-0:
+    shape: [2]
+    dtype: tensor(float)
+    labels: [min, max]'''
+        ),
+        (
+            audonnx.testing.create_model(
+                [[2], [None], [1, -1, 3], [99, 'time']],
+            ), r'''Input:
+  input-0:
+    shape: [2]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(reshape)
+  input-1:
+    shape: [-1]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(reshape)
+  input-2:
+    shape: [1, -1, 3]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(reshape)
+  input-3:
+    shape: [99, -1]
+    dtype: tensor(float)
+    transform: audonnx.core.function.Function(reshape)
+Output:
+  output-0:
+    shape: [2]
+    dtype: tensor(float)
+    labels: [output-0-0, output-0-1]
+  output-1:
+    shape: [-1]
+    dtype: tensor(float)
+    labels: []
+  output-2:
+    shape: [1, -1, 3]
+    dtype: tensor(float)
+    labels: [output-2-0, output-2-1, output-2-2]
+  output-3:
+    shape: [99, -1]
+    dtype: tensor(float)
+    labels: [output-3-0, output-3-1, output-3-2, (...), output-3-96, output-3-97,
+      output-3-98]'''  # noqa: E501
         )
     ],
 )

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3,6 +3,10 @@ import pytest
 import audonnx
 
 
+def mean(x, sr):
+    return x.mean(axis=1)
+
+
 @pytest.mark.parametrize(
     'node, expected',
     [
@@ -22,6 +26,24 @@ import audonnx
             ),
             "{shape: [18, -1], dtype: tensor(float), "
             "transform: opensmile.core.smile.Smile}"
+        ),
+        (
+            audonnx.InputNode(
+                [1],
+                'tensor(float)',
+                audonnx.Function(lambda x, sr: x.mean(axis=1)),
+            ),
+            "{shape: [1], dtype: tensor(float), "
+            "transform: audonnx.core.function.Function(<lambda>)}"
+        ),
+        (
+            audonnx.InputNode(
+                [1],
+                'tensor(float)',
+                audonnx.Function(mean),
+            ),
+            "{shape: [1], dtype: tensor(float), "
+            "transform: audonnx.core.function.Function(mean)}"
         ),
         (
             audonnx.OutputNode(


### PR DESCRIPTION
All test are now based on `audonnx.testing`.

To make it easier writing the tests I added `testing.create_model_proto()` to the API:

![image](https://user-images.githubusercontent.com/10383417/174812846-25700678-ce09-4e0b-9a6f-3d87063488c0.png)
