### PR TITLE
Use audeer.path() instead of audeer.safe_path()

### DIFF
--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -67,7 +67,7 @@ def load(
 
     """  # noqa: E501
 
-    root = audeer.safe_path(root)
+    root = audeer.path(root)
     model_file = os.path.join(root, model_file)
     model_file_yaml = audeer.replace_file_extension(model_file, 'yaml')
     if audeer.file_extension(model_file) == 'yaml':

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -122,7 +122,7 @@ class Model(audobject.Object):
             'transform': transform,
         }
 
-        self.path = audeer.safe_path(path) if isinstance(path, str) else None
+        self.path = audeer.path(path) if isinstance(path, str) else None
         r"""Model path"""
 
         providers = _device_to_providers(device)
@@ -298,7 +298,7 @@ class Model(audobject.Object):
             ValueError: if file path does not end on ``.yaml``
 
        """
-        path = audeer.safe_path(path)
+        path = audeer.path(path)
         if not audeer.file_extension(path) == 'yaml':
             raise ValueError(f"Model path {path} does not end on '.yaml'")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import audiofile
 import audobject
 
 
-pytest.ROOT = audeer.safe_path(
+pytest.ROOT = audeer.path(
     os.path.dirname(os.path.realpath(__file__))
 )
 pytest.TMP = audeer.mkdir(


### PR DESCRIPTION
As we have already

```
audobject >=0.7.1
```
in the requirements and `audobject >=0.7.1` depends on `audeer >=1.18.0` it's safe to simply switch to `audeer.path()`.