### PR TITLE
Rename argument output_names to outputs

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -194,12 +194,17 @@ class Model(audobject.Object):
                 lab,
             )
 
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='output_names',
+        removal_version='1.2.0',
+        new_argument='outputs',
+    )
     def __call__(
             self,
             signal: np.ndarray,
             sampling_rate: int,
             *,
-            output_names: typing.Union[str, typing.Sequence[str]] = None,
+            outputs: typing.Union[str, typing.Sequence[str]] = None,
     ) -> typing.Union[
         np.ndarray,
         typing.Dict[str, np.ndarray],
@@ -224,16 +229,16 @@ class Model(audobject.Object):
         Args:
             signal: input signal
             sampling_rate: sampling rate in Hz
-            output_names: name of output or list with output names
+            outputs: name of output or list with output names
 
         Returns:
             model output
 
         """
-        if output_names is None:
-            output_names = list(self.outputs)
-            if len(output_names) == 1:
-                output_names = output_names[0]
+        if outputs is None:
+            outputs = list(self.outputs)
+            if len(outputs) == 1:
+                outputs = outputs[0]
 
         y = {}
         for name, input in self.inputs.items():
@@ -244,15 +249,15 @@ class Model(audobject.Object):
             y[name] = x.reshape(self.inputs[name].shape)
 
         z = self.sess.run(
-            audeer.to_list(output_names),
+            audeer.to_list(outputs),
             y,
         )
 
-        if isinstance(output_names, str):
+        if isinstance(outputs, str):
             z = z[0]
         else:
             z = {
-                name: values for name, values in zip(output_names, z)
+                name: values for name, values in zip(outputs, z)
             }
 
         return z

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -84,7 +84,7 @@ class Model(audobject.Object):
         >>> model(
         ...     signal,
         ...     sampling_rate,
-        ...     output_names='gender',
+        ...     outputs='gender',
         ... ).round(1)
         array([-195.1,   73.3], dtype=float32)
 
@@ -211,19 +211,19 @@ class Model(audobject.Object):
     ]:
         r"""Compute output for one or more nodes.
 
-        If ``output_names`` is a plain string,
+        If ``outputs`` is a plain string,
         the output of the according node is returned.
 
-        If ``output_names`` is a list of strings,
+        If ``outputs`` is a list of strings,
         a dictionary with according nodes as keys and
         their outputs as values is returned.
 
-        If ``output_names`` is not set
+        If ``outputs`` is not set
         and the model has a single output node,
         the output of that node is returned.
         Otherwise a dictionary with outputs of all nodes is returned.
 
-        Use :attr:`audonnx.Model.output_names` to get a list of available
+        Use :attr:`audonnx.Model.outputs` to get a list of available
         output nodes.
 
         Args:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -436,7 +436,7 @@ To request specific nodes.
     onnx_model_7(
         signal,
         sampling_rate,
-        output_names=['gender', 'confidence'],
+        outputs=['gender', 'confidence'],
     )
 
 Or a single node:
@@ -446,7 +446,7 @@ Or a single node:
     onnx_model_7(
         signal,
         sampling_rate,
-        output_names='gender',
+        outputs='gender',
     )
 
 Create interface and process a file.
@@ -456,7 +456,7 @@ Create interface and process a file.
     interface = audinterface.Feature(
         feature_names=onnx_model_7.outputs['gender'].labels,
         process_func=onnx_model,
-        process_func_args={'output_names': 'gender'},
+        process_func_args={'outputs': 'gender'},
     )
     interface.process_file(file)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,7 +11,7 @@ def min_max(x, sr):
 
 
 @pytest.mark.parametrize(
-    'model, output_names, expected',
+    'model, outputs, expected',
     [
         (
             audonnx.Model(audonnx.testing.create_model_proto([[1, -1]])),
@@ -71,11 +71,11 @@ def min_max(x, sr):
         ),
     ]
 )
-def test_call(model, output_names, expected):
+def test_call(model, outputs, expected):
     y = model(
         pytest.SIGNAL,
         pytest.SAMPLING_RATE,
-        output_names=output_names,
+        outputs=outputs,
     )
     if isinstance(y, dict):
         for key, values in y.items():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,6 +85,35 @@ def test_call(model, outputs, expected):
 
 
 @pytest.mark.parametrize(
+    'model, output_names',
+    [
+        (
+            audonnx.testing.create_model([[2], [1, 3]]),
+            'output-1',
+        ),
+    ]
+)
+def test_call_deprecated(model, output_names):
+    if (
+            audeer.LooseVersion(audonnx.__version__)
+            < audeer.LooseVersion('1.2.0')
+    ):
+        with pytest.warns(UserWarning, match='is deprecated'):
+            model(
+                pytest.SIGNAL,
+                pytest.SAMPLING_RATE,
+                output_names=output_names,
+            )
+    else:
+        with pytest.raises(TypeError, match='unexpected keyword argument'):
+            model(
+                pytest.SIGNAL,
+                pytest.SAMPLING_RATE,
+                output_names=output_names,
+            )
+
+
+@pytest.mark.parametrize(
     'device',
     [
         'cpu',


### PR DESCRIPTION
Closes #26 

![image](https://user-images.githubusercontent.com/10383417/174880076-fb2b1ae8-a06b-4766-9525-91c04dfa2bf1.png)

```python
import audonnx.testing


sampling_rate = 16000
signal = np.zeros((1, 10), np.float32)

shapes = [[1, 2], [3, -1]]
model = audonnx.testing.create_model(shapes)
model(signal, sampling_rate, output_names='output-0')
```
```
UserWarning: 'output_names' argument is deprecated and will be removed with version 1.2.0. Use 'outputs' instead.
  y = model(signal, sampling_rate, output_names='output-0')
[[0. 0.]]
```