### PR TITLE
TST: enable Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macOS-latest ]
+        os: [ ubuntu-20.04, macOS-latest, windows-latest ]
         python-version: [3.8]
         include:
           - os: ubuntu-latest

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,6 +5,8 @@ import sys
 
 import pytest
 
+import opensmile
+
 import audonnx.testing
 
 
@@ -40,6 +42,9 @@ def test(tmpdir):
     )
     model_path = os.path.join(tmpdir, 'model.yaml')
     model.to_yaml(model_path)
+
+    # ensure DLL file is unloaded
+    del opensmile.core.SMILEapi.smileapi
 
     uninstall('opensmile', 'opensmile')
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -43,12 +43,12 @@ def test(tmpdir):
     model_path = os.path.join(tmpdir, 'model.yaml')
     model.to_yaml(model_path)
 
-    # ensure DLL file is unloaded
-    del opensmile.core.SMILEapi.smileapi
+    # Removing the package does not work under Windows
+    # as the DLL file cannot be unloaded
+    if not sys.platform == 'win32':
+        uninstall('opensmile', 'opensmile')
 
-    uninstall('opensmile', 'opensmile')
-
-    with pytest.raises(ModuleNotFoundError):
-        audonnx.load(tmpdir)
+        with pytest.raises(ModuleNotFoundError):
+            audonnx.load(tmpdir)
 
     audonnx.load(tmpdir, auto_install=True)


### PR DESCRIPTION
Closes #2 

This enables tests under Windows.
Only one test for `auto_install` is skipped as deinstalling `opensmile` under Windows does not work as we don't have the permission to remove the included DLL file when this is still loaded.