### PR TITLE
Add option to concatenate outputs

### DIFF
--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -378,7 +378,7 @@ def _concat(
         return np.stack(y)
 
     axis = _concat_axis(shapes)
-    if axis == -1:
+    if axis is None:
         raise RuntimeError(
             f'To concatenate outputs '
             f'number of dimensions, '
@@ -392,16 +392,16 @@ def _concat(
     return np.concatenate(y, axis=axis)
 
 
-def _concat_axis(shapes: typing.Sequence[int]) -> int:
-    r"""Return concat dimension or -1 if not possible."""
+def _concat_axis(shapes: typing.Sequence[int]) -> typing.Optional[int]:
+    r"""Return concat dimension or None if not possible."""
 
     # number of dimensions do not match
     if not len(set(map(len, shapes))) == 1:
-        return -1
+        return None
 
     # dynamic axis in different positions
     if not len(set(map(_dynamic_axis, shapes))) == 1:
-        return -1
+        return None
 
     # select last non-dynamic axis
     axis = len(shapes[0]) - (2 if shapes[0][-1] == -1 else 1)
@@ -411,17 +411,17 @@ def _concat_axis(shapes: typing.Sequence[int]) -> int:
 
     # non-concat dimensions do not match
     if not all(map(shapes_wo_axis[0].__eq__, shapes_wo_axis)):
-        return -1
+        return None
 
     return axis
 
 
-def _dynamic_axis(shape: typing.Sequence[int]) -> int:
-    r"""Return dimension of dynamic axis or -1 if none."""
+def _dynamic_axis(shape: typing.Sequence[int]) -> typing.Optional[int]:
+    r"""Return dimension of dynamic axis or None if none."""
     for idx, dim in enumerate(shape):
         if dim == -1:
             return idx
-    return -1
+    return None
 
 
 def _last_static_dim_size(

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -226,6 +226,7 @@ class Model(audobject.Object):
 
         If ``concat`` is set to ``True``,
         the output of the requested nodes is concatenated
+        along the last non-dynamic axis
         and a single array is returned.
         This requires that the number of dimensions,
         the position of dynamic axis,

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -403,6 +403,7 @@ def _concat_axis(shapes: typing.Sequence[int]) -> int:
     if not len(set(map(_dynamic_axis, shapes))) == 1:
         return -1
 
+    # select last non-dynamic axis
     axis = len(shapes[0]) - (2 if shapes[0][-1] == -1 else 1)
 
     # remove concat axis

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -449,7 +449,7 @@ Or provide a list of names to request several outputs.
         outputs=['gender', 'confidence'],
     )
 
-To get a concatation of the outputs,
+To concatenate the outputs to a single array,
 do:
 
 .. jupyter-execute::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -381,7 +381,7 @@ the output from the hidden layer and a confidence value.
             return (
                 y_hidden.squeeze(),
                 y_gender.squeeze(),
-                y_confidence.squeeze(),
+                y_confidence,
             )
 
 Export the new model to ONNX_ format and load it.
@@ -429,17 +429,7 @@ returns a dictionary with output for every node.
 
     onnx_model_7(signal, sampling_rate)
 
-To request specific nodes.
-
-.. jupyter-execute::
-
-    onnx_model_7(
-        signal,
-        sampling_rate,
-        outputs=['gender', 'confidence'],
-    )
-
-Or a single node:
+To request a specific node use the ``outputs`` argument.
 
 .. jupyter-execute::
 
@@ -449,14 +439,41 @@ Or a single node:
         outputs='gender',
     )
 
+Or provide a list of names to request several outputs.
+
+.. jupyter-execute::
+
+    onnx_model_7(
+        signal,
+        sampling_rate,
+        outputs=['gender', 'confidence'],
+    )
+
+To get a concatation of the outputs,
+do:
+
+.. jupyter-execute::
+
+    onnx_model_7(
+        signal,
+        sampling_rate,
+        outputs=['gender', 'confidence'],
+        concat=True,
+    )
+
 Create interface and process a file.
 
 .. jupyter-execute::
 
+    feature_names = onnx_model_7.outputs['gender'].labels + \
+        onnx_model_7.outputs['confidence'].labels
     interface = audinterface.Feature(
-        feature_names=onnx_model_7.outputs['gender'].labels,
-        process_func=onnx_model,
-        process_func_args={'outputs': 'gender'},
+        feature_names=feature_names,
+        process_func=onnx_model_7,
+        process_func_args={
+            'outputs': ['gender', 'confidence'],
+            'concat': True,
+        },
     )
     interface.process_file(file)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -205,12 +205,12 @@ def test_call_deprecated(model, output_names):
         ),
     ]
 )
-def test_call_flatten(model, outputs, expected):
+def test_call_concat(model, outputs, expected):
     y = model(
         pytest.SIGNAL,
         pytest.SAMPLING_RATE,
         outputs=outputs,
-        flatten=True,
+        concat=True,
     )
     np.testing.assert_equal(y, expected)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -114,6 +114,108 @@ def test_call_deprecated(model, output_names):
 
 
 @pytest.mark.parametrize(
+    'model, outputs, expected',
+    [
+        (
+            audonnx.Model(audonnx.testing.create_model_proto([[1, -1]])),
+            None,
+            pytest.SIGNAL,
+        ),
+        (
+            audonnx.testing.create_model([[-1], [-1]]),
+            None,
+            np.zeros([2, pytest.SIGNAL.shape[1]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[2]]),
+            None,
+            np.array([0, 0], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[2], [3]]),
+            None,
+            np.array([0, 0, 0, 0, 0], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, 2], [1, 3]]),
+            None,
+            np.array([[0, 0, 0, 0, 0]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[2, -1], [3, -1]]),
+            None,
+            np.zeros([5, pytest.SIGNAL.shape[1]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[-1, 2], [-1, 3]]),
+            None,
+            np.zeros([pytest.SIGNAL.shape[1], 5], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, -1, 2], [1, -1, 3]]),
+            None,
+            np.zeros([1, pytest.SIGNAL.shape[1], 5], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, 2, -1], [1, 3, -1]]),
+            None,
+            np.zeros([1, 5, pytest.SIGNAL.shape[1]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, 3], [2]]),
+            'output-0',
+            np.array([[0, 0, 0]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, 3], [2]]),
+            ['output-0'],
+            np.array([[0, 0, 0]], dtype=np.float32),
+        ),
+        (
+            audonnx.testing.create_model([[1, 3], [2], [3]]),
+            ['output-1', 'output-2'],
+            np.array([0, 0, 0, 0, 0], dtype=np.float32),
+        ),
+        # shapes do not match
+        pytest.param(
+            audonnx.testing.create_model([[1, 3], [2]]),
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        # position of dynamic axis do not match
+        pytest.param(
+            audonnx.testing.create_model([[-1, 1, 3], [1, -1, 2]]),
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            audonnx.testing.create_model([[1, 3], [-1, 2]]),
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        # non-concat dimensions do not match
+        pytest.param(
+            audonnx.testing.create_model([[1, 3], [2, 3]]),
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+    ]
+)
+def test_call_flatten(model, outputs, expected):
+    y = model(
+        pytest.SIGNAL,
+        pytest.SAMPLING_RATE,
+        outputs=outputs,
+        flatten=True,
+    )
+    np.testing.assert_equal(y, expected)
+
+
+@pytest.mark.parametrize(
     'device',
     [
         'cpu',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -183,7 +183,7 @@ def test_call_deprecated(model, output_names):
             None,
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
-        # position of dynamic axis do not match
+        # position of dynamic axis does not match
         pytest.param(
             audonnx.testing.create_model([[-1, 1, 3], [1, -1, 2]]),
             None,


### PR DESCRIPTION
Adds new keyword argument `concat` to `Model__call__()`. If set to `True` the output of the requested nodes will be concatenated:

![image](https://user-images.githubusercontent.com/10383417/175009022-95fc806c-da65-4053-ab68-690b17c3bfd5.png)

![image](https://user-images.githubusercontent.com/10383417/174987838-999d9510-6a88-408b-82e8-962ec94a61f6.png)

### Example

```python
import audonnx.testing


sampling_rate = 16000
signal = np.zeros((1, 10), np.float32)


shapes = [[1, 3], [1, 2]]
model = audonnx.testing.create_model(shapes)

model(signal, sampling_rate)
```
```
{'output-0': array([[0., 0., 0.]], dtype=float32), 'output-1': array([[0., 0.]], dtype=float32)}
```

```python
model(signal, sampling_rate, concat=True)
```
```
[[0. 0. 0. 0. 0.]]
```