### PR TITLE
Add missing onnx to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@ opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 librosa
-onnx
 protobuf <=3.20.1  # avoid TypeError: Descriptors cannot not be created directly
 torch
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audobject >=0.7.1
+    onnx >=1.8.0
     onnxruntime >=1.8.0
 setup_requires =
     setuptools_scm != 7.0.0  # https://github.com/pypa/setuptools_scm/issues/718

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audobject >=0.7.1
-    onnx >=1.8.0
+    onnx
     onnxruntime >=1.8.0
 setup_requires =
     setuptools_scm != 7.0.0  # https://github.com/pypa/setuptools_scm/issues/718


### PR DESCRIPTION
Closes #40 

Adds `onnx >=1.8.0` to `install_requires` in `setup.cfg`.