### PR TITLE
Require audobject>=0.7.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audobject >=0.7.1
+    audobject >=0.7.2
     onnx
     onnxruntime >=1.8.0
 setup_requires =


### PR DESCRIPTION
Update to `audobject>=0.7.2` to avoid bug with `audinterface>=0.9.0`, see https://github.com/audeering/audinterface/issues/68