### PR TITLE
TST: require flake<5.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 librosa
+onnx <=1.13.0  # https://github.com/audeering/audonnx/issues/48
 protobuf <=3.20.1  # avoid TypeError: Descriptors cannot not be created directly
 torch
 sphinx

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,8 @@ opensmile >=2.3.0
 audobject >=0.7.1
 # To avoid https://github.com/tholo/pytest-flake8/issues/87
 flake8 <5.0.0
+# To work with flake8<5.0.0, https://stackoverflow.com/a/73932581
+importlib-metadata <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,8 @@ opensmile >=2.3.0
 # Avoid pip error on Python 3.7,
 # compare https://github.com/audeering/audonnx/runs/5737150095
 audobject >=0.7.1
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus


### PR DESCRIPTION
To avoid an error with pytest-flake8 (https://github.com/tholo/pytest-flake8/issues/87), this requires `flake<5.0.0`