### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        ls ~/.cache/pre-commit
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r docs/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache pre-commit repos
+      uses: actions/cache@v3
+      id: cache-precommit
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -41,7 +48,8 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Installing pre-commit hooks
+    - name: Installing pre-commit hooks (cached)
+      if: steps.cache-precommit.outputs.cache-hit != 'true'
       run: |
         pre-commit install --install-hooks
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       id: cache-precommit
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit
+        key: pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache pre-commit repos
-      uses: actions/cache@v3
-      id: cache-precommit
-      with:
-        path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -48,8 +41,7 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Installing pre-commit hooks (cached)
-      if: steps.cache-precommit.outputs.cache-hit != 'true'
+    - name: Installing pre-commit hooks
       run: |
         pre-commit install --install-hooks
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    # Cache CI packages
+    - uses: actions/cache@v3
+      id: cache-precommit
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -36,9 +44,19 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install pre-commit
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
+
+    - name: Installing pre-commit hooks (cached)
+      if: steps.cache-precommit.outputs.cache-hit != 'true'
+       run: |
+         pre-commit install --install-hooks
+
+    - name: Run style checking via pre-commit
+      run: |
+         pre-commit run --all-files
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache pre-commit repos
-      uses: actions/cache@v3
-      id: cache-precommit
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -43,13 +36,12 @@ jobs:
 
     - name: Install dependencies
       run: |
-        ls ~/.cache/pre-commit
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Install pre-commit hooks (cached)
+    - name: Install pre-commit hooks
       run: |
         pre-commit install --install-hooks
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       id: cache-precommit
       with:
         path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
+        key: pre-commit
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -49,7 +49,6 @@ jobs:
         pip install -r tests/requirements.txt
 
     - name: Installing pre-commit hooks (cached)
-      if: steps.cache-precommit.outputs.cache-hit != 'true'
       run: |
         pre-commit install --install-hooks
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pre-commit
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,11 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Installing pre-commit hooks (cached)
+    - name: Install pre-commit hooks (cached)
       run: |
         pre-commit install --install-hooks
 
-    - name: Run style checking via pre-commit
+    - name: Code style check via pre-commit
       run: |
         pre-commit run --all-files
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Cache CI packages
-    - uses: actions/cache@v3
+    - name: Cache pre-commit repos
+      uses: actions/cache@v3
       id: cache-precommit
       with:
         path: ~/.cache/pre-commit
@@ -51,16 +51,17 @@ jobs:
 
     - name: Installing pre-commit hooks (cached)
       if: steps.cache-precommit.outputs.cache-hit != 'true'
-       run: |
-         pre-commit install --install-hooks
+      run: |
+        pre-commit install --install-hooks
 
     - name: Run style checking via pre-commit
       run: |
-         pre-commit run --all-files
+        pre-commit run --all-files
 
     - name: Test with pytest
       run: |
         python -m pytest
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See CONTRIBUTING.rst,
+# we expect this to be run via a git pre-commit hook.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,10 @@
-# See CONTRIBUTING.rst,
-# we expect this to be run via a git pre-commit hook.
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
 # You can also run the checks directly at the terminal, e.g.
 #
+# $ pre-commit install
 # $ pre-commit run --all-files
 #
 repos:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,6 +54,10 @@ and call it directly::
     pip install flake8  # you might consider system wide installation
     flake8
 
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/
 .. _flake8: https://flake8.pycqa.org/en/latest/index.html
 .. _pre-commit: https://pre-commit.com

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,6 +48,12 @@ You can enable those checks locally by executing::
 Afterwards flake8_ is executed
 every time you create a commit.
 
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/
 .. _flake8: https://flake8.pycqa.org/en/latest/index.html
 .. _pre-commit: https://pre-commit.com

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,29 @@ This way, your installation always stays up-to-date,
 even if you pull new changes from the Github repository.
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -8,7 +8,7 @@ import audobject
 
 from audonnx.core.model import Model
 
-
+  
 def load(
         root: str,
         *,

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -8,7 +8,7 @@ import audobject
 
 from audonnx.core.model import Model
 
-  
+
 def load(
         root: str,
         *,

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -1,5 +1,6 @@
 import typing
 
+import numpy as np  # noqa: F401, needed for doctest
 import onnx
 
 from audonnx.core.function import Function

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -1,10 +1,6 @@
 import typing
 
-import numpy as np
 import onnx
-
-import audeer
-import audobject
 
 from audonnx.core.function import Function
 from audonnx.core.model import Model

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 librosa
+onnx <=1.13.0  # https://github.com/audeering/audonnx/issues/48
 protobuf <=3.20.1  # avoid TypeError: Descriptors cannot not be created directly
 torch
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audonnx
     --cov-fail-under=100

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,12 @@ addopts =
 xfail_strict = true
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 import audeer
 import audiofile
-import audobject
 import opensmile
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,8 @@ opensmile >=2.3.0
 audobject >=0.7.1
 # To avoid https://github.com/tholo/pytest-flake8/issues/87
 flake8 <5.0.0
+# To work with flake8<5.0.0, https://stackoverflow.com/a/73932581
+importlib-metadata <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,12 +2,8 @@ opensmile >=2.3.0
 # Avoid pip error on Python 3.7,
 # compare https://github.com/audeering/audonnx/runs/5737150095
 audobject >=0.7.1
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
-# To work with flake8<5.0.0, https://stackoverflow.com/a/73932581
-importlib-metadata <5.0.0
+pre-commit
 pytest
-pytest-flake8
 pytest-doctestplus
 pytest-console-scripts
 pytest-cov

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,8 @@ opensmile >=2.3.0
 # Avoid pip error on Python 3.7,
 # compare https://github.com/audeering/audonnx/runs/5737150095
 audobject >=0.7.1
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,8 +5,6 @@ import sys
 
 import pytest
 
-import opensmile
-
 import audonnx.testing
 
 


### PR DESCRIPTION
Alternative to https://github.com/audeering/audonnx/pull/47

This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.