### PR TITLE
DOC: fix typo in config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,6 @@ title = 'Documentation'
 # General -----------------------------------------------------------------
 master_doc = 'index'
 source_suffix = '.rst'
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 exclude_patterns = [
     'api-src',
     'build',


### PR DESCRIPTION
`exclude_patterns` was defined twice in `docs/conf.py`