### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/audonnx/__init__.py
+++ b/audonnx/__init__.py
@@ -12,9 +12,9 @@ __all__ = []
 
 # Dynamically get the version of the installed module
 try:
-    import pkg_resources
-    __version__ = pkg_resources.get_distribution(__name__).version
+    import importlib.metadata
+    __version__ = importlib.metadata.version(__name__)
 except Exception:  # pragma: no cover
-    pkg_resources = None  # pragma: no cover
+    importlib = None  # pragma: no cover
 finally:
-    del pkg_resources
+    del importlib


### PR DESCRIPTION
`pkg_resources` is deprecated and since Python 3.8 we can use `importlib.metadata` to get the version of a package.