### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [ '3.8' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.7'
-          - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.10'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
Python 3.7 has reached its end of life and we remove it here.