### PR TITLE
DOC: do not restrict onnx and protobuf versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,5 +54,5 @@ jobs:
 
     - name: Test building documentation
       run: |
-        python -m sphinx docs/ docs/_build/ -b html -W
+        python -m sphinx docs/ docs/_build/ -b html
       if: matrix.os == 'ubuntu-20.04'

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -136,7 +136,10 @@ def create_model_proto(
 
     Examples:
         >>> create_model_proto([[2]])
-        ir_version: 8
+        ir_version: 9
+        opset_import {
+          version: 14
+        }
         producer_name: "test"
         graph {
           node {
@@ -171,9 +174,6 @@ def create_model_proto(
               }
             }
           }
-        }
-        opset_import {
-          version: 14
         }
         <BLANKLINE>
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,8 +3,8 @@ opensmile >=2.4.0
 jupyter
 jupyter-sphinx
 librosa
-onnx <=1.13.0  # https://github.com/audeering/audonnx/issues/48
-protobuf <=3.20.1  # avoid TypeError: Descriptors cannot not be created directly
+onnx
+protobuf
 torch
 sphinx
 sphinx-audeering-theme >=1.0.14


### PR DESCRIPTION
Closes https://github.com/audeering/audonnx/issues/48

Newer versions of `onnx` and `protobuf` are now compatible and we can use them (we also have to use them to be compatible with newer `onnxruntime` versions).