### PR TITLE
DOC: add pre-processing stage for quantization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,5 +54,5 @@ jobs:
 
     - name: Test building documentation
       run: |
-        python -m sphinx docs/ docs/_build/ -b html
+        python -m sphinx docs/ docs/_build/ -b html -W
       if: matrix.os == 'ubuntu-20.04'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -251,7 +251,8 @@ Quantize weights
 ----------------
 
 To reduce the memory print of a model,
-we can quantize it.
+we can quantize it,
+compare the `MobilenetV2 example`_.
 For instance, we can store model weights as 8 bit integers.
 For quantization make sure
 you have installed
@@ -513,6 +514,7 @@ In that case do:
 .. _audinterface: http://tools.pp.audeering.com/audinterface/
 .. _audobject: http://tools.pp.audeering.com/audobject/
 .. _librosa: https://librosa.org/doc/main/index.html
+.. _MobilenetV2 example: https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification/cpu/ReadMe.md#onnx-runtime-quantization-example
 .. _ONNX: https://onnx.ai/
 .. _OpenSMILE: https://github.com/audeering/opensmile-python
 .. _table: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -264,9 +264,14 @@ as well as
     import onnxruntime.quantization
 
 
+    onnx_infer_path = os.path.join(onnx_root, 'model_infer.onnx')
+    onnxruntime.quantization.quant_pre_process(
+        onnx_model_path,
+        onnx_infer_path,
+    )
     onnx_quant_path = os.path.join(onnx_root, 'model_quant.onnx')
     onnxruntime.quantization.quantize_dynamic(
-        onnx_model_path,
+        onnx_infer_path,
         onnx_quant_path,
         weight_type=onnxruntime.quantization.QuantType.QUInt8,
     )


### PR DESCRIPTION
Closes #67

This adds a pre-processing step before the quantization of the model as proposed at https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification/cpu/ReadMe.md#pre-processing.
When not adding this stage, the quantization will raise a warning message that we should apply pre-processing.
This was also the reason the `-W` flag was deactivated when building the docs, which I revert in this pull request.

The page linked above states:

> The pre-processing consists of the following optional steps
>
> * Symbolic Shape Inference. It works best with transformer models.
> * ONNX Runtime Model Optimization.
> * ONNX Shape Inference.
>
> Quantization requires tensor shape information to perform its best. Model optimization also improve the performance of quantization. For instance, a Convolution node followed by a BatchNormalization node can be merged into a single node during optimization. Currently we can not quantize BatchNormalization by itself, but we can quantize the merged Convolution + BatchNormalization node.
>
>It is highly recommended to run model optimization in pre-processing instead of in quantization. To learn more about each of these steps and finer controls, run:

I added the pre-processing to the quantization example, and also a link to the official mobilenet/resnet example:

![image](https://github.com/audeering/audonnx/assets/173624/ae5d2b6c-1bbb-4e6f-978a-d8499cdba572)




