### PR TITLE
CI: fix permissions to publish Github pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      pages: write
       id-token: write
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      pages: write
+      contents: write
       id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Following the code example from https://github.com/actions/deploy-pages this tries to fix write permissions to publish to Github pages.