### PR TITLE
TST: remove deprecated pkg_resources

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 
-import pkg_resources
 import pytest
 
 import audonnx.testing
@@ -27,8 +26,6 @@ def uninstall(
     for m in list(sys.modules):
         if m.startswith(package):
             sys.modules.pop(m)
-    # force pkg_resources to re-scan site packages
-    pkg_resources._initialize_master_working_set()
 
 
 def test(tmpdir):


### PR DESCRIPTION
In the tests we use `pkg_resources` to re-scan available side packages.

As we cannot simply delete it, we need to find a replacement for it.