### PR TITLE
Add num_workers to audonnx.Model and load()

### DIFF
--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -20,6 +20,7 @@ def load(
             typing.Tuple[str, typing.Dict],
             typing.Sequence[typing.Union[str, typing.Tuple[str, typing.Dict]]],
         ] = 'cpu',
+        num_workers: typing.Optional[int] = 1,
         auto_install: bool = False,
 ) -> Model:
     r"""Load model from folder.
@@ -44,6 +45,9 @@ def load(
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a (list of) provider_
+        num_workers: number of threads for running
+            onnxruntime inference on cpu.
+            If ``None`` onnxruntime chooses the number of threads
         auto_install: install missing packages needed to create the object
 
     .. _provider: https://onnxruntime.ai/docs/execution-providers/
@@ -85,6 +89,7 @@ def load(
                 auto_install=auto_install,
                 override_args={
                     'device': device,
+                    'num_workers': num_workers,
                 },
             )
 
@@ -111,6 +116,7 @@ def load(
         labels=labels,
         transform=transform,
         device=device,
+        num_workers=num_workers,
     )
 
     return model

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -15,6 +15,7 @@ def create_model(
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
         device: Device = 'cpu',
+        num_workers: typing.Optional[int] = 1,
 ) -> Model:
     r"""Create test model.
 
@@ -36,6 +37,9 @@ def create_model(
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a (list of) provider(s)_
+        num_workers: number of threads for running
+            onnxruntime inference on cpu.
+            If ``None`` onnxruntime chooses the number of threads
 
     Returns:
         model object
@@ -99,6 +103,7 @@ def create_model(
         object,
         transform=transform,
         device=device,
+        num_workers=num_workers,
     )
 
     return model

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -229,6 +229,29 @@ def test_call_concat(model, outputs, expected):
 
 
 @pytest.mark.parametrize(
+    'device, num_workers',
+    [
+        ('cpu', None),
+        ('cuda:0', None),
+        ('cpu', 1),
+        ('cuda:0', 1),
+        ('cpu', 2),
+        ('cuda:0', 2),
+    ]
+)
+def test_call_num_workers(device, num_workers):
+    model = audonnx.testing.create_model(
+        [[2]], device=device, num_workers=num_workers
+    )
+    y = model(
+        pytest.SIGNAL,
+        pytest.SAMPLING_RATE,
+    )
+    expected = np.array([0.0, 0.0], np.float32)
+    np.testing.assert_equal(y, expected)
+
+
+@pytest.mark.parametrize(
     'device',
     [
         'cpu',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -228,17 +228,8 @@ def test_call_concat(model, outputs, expected):
             np.testing.assert_equal(y, expected)
 
 
-@pytest.mark.parametrize(
-    'device, num_workers',
-    [
-        ('cpu', None),
-        ('cuda:0', None),
-        ('cpu', 1),
-        ('cuda:0', 1),
-        ('cpu', 2),
-        ('cuda:0', 2),
-    ]
-)
+@pytest.mark.parametrize('device', ['cpu', 'cuda:0'])
+@pytest.mark.parametrize('num_workers', [None, 1, 2])
 def test_call_num_workers(device, num_workers):
     model = audonnx.testing.create_model(
         [[2]], device=device, num_workers=num_workers


### PR DESCRIPTION
Closes #80 

This adds the `num_workers` argument to `audonnx.Model` and `audonnx.load()`. It now only uses 1 thread by default, whereas before onnxruntime chose the number by default.

The `num_workers` argument was also added to `audonnx.testing.create_model()`.

![image](https://github.com/audeering/audonnx/assets/99745980/559579cc-a7ee-4a31-a60a-f609b0a3d9d5)

![image](https://github.com/audeering/audonnx/assets/99745980/2fb32df0-668c-40b6-9da9-ad6a689ed2b7)

![image](https://github.com/audeering/audonnx/assets/99745980/4b3bc509-9e89-4bed-bab5-54037e78dfac)

