### PR TITLE
Add session_options to audonnx.Model and load()

### DIFF
--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -46,7 +46,7 @@ def load(
         transform_file: YAML file with transformation
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
-            or a (list of) provider_
+            or a (list of) `provider(s)`_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
@@ -61,7 +61,7 @@ def load(
             for inference on cpu and ``num_workers`` is ignored.
         auto_install: install missing packages needed to create the object
 
-    .. _provider: https://onnxruntime.ai/docs/execution-providers/
+    .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
     .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
     .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -58,7 +58,7 @@ def load(
             and the ``session_options`` properties
             inter_op_num_threads_ and intra_op_num_threads_
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored.
+            for inference on cpu and ``num_workers`` is ignored
         auto_install: install missing packages needed to create the object
 
     .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -1,6 +1,7 @@
 import os
 import typing
 
+import onnxruntime
 import oyaml as yaml
 
 import audeer
@@ -21,6 +22,7 @@ def load(
             typing.Sequence[typing.Union[str, typing.Tuple[str, typing.Dict]]],
         ] = 'cpu',
         num_workers: typing.Optional[int] = 1,
+        session_options: typing.Optional[onnxruntime.SessionOptions] = None,
         auto_install: bool = False,
 ) -> Model:
     r"""Load model from folder.
@@ -47,10 +49,22 @@ def load(
             or a (list of) provider_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
-            If ``None`` onnxruntime chooses the number of threads
+            If ``None`` and ``session_options`` is ``None``,
+            onnxruntime chooses the number of threads
+        session_options: onnxruntime.SessionOptions_ to use for inference.
+            If ``None`` the default options are used and the number of
+            threads for running inference on cpu is determined
+            by ``num_workers``. Otherwise, the provided options are used
+            and the ``session_options`` properties
+            inter_op_num_threads_ and intra_op_num_threads_
+            determine the number of threads
+            for inference on cpu and ``num_workers`` is ignored.
         auto_install: install missing packages needed to create the object
 
     .. _provider: https://onnxruntime.ai/docs/execution-providers/
+    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
+    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
+    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     Returns:
         model
@@ -90,6 +104,7 @@ def load(
                 override_args={
                     'device': device,
                     'num_workers': num_workers,
+                    'session_options': session_options,
                 },
             )
 
@@ -117,6 +132,7 @@ def load(
         transform=transform,
         device=device,
         num_workers=num_workers,
+        session_options=session_options,
     )
 
     return model

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -51,20 +51,19 @@ def load(
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
             onnxruntime chooses the number of threads
-        session_options: onnxruntime.SessionOptions_ to use for inference.
+        session_options: :class:`onnxruntime.SessionOptions`
+            to use for inference.
             If ``None`` the default options are used and the number of
             threads for running inference on cpu is determined
             by ``num_workers``. Otherwise, the provided options are used
             and the ``session_options`` properties
-            inter_op_num_threads_ and intra_op_num_threads_
+            :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
+            and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
             for inference on cpu and ``num_workers`` is ignored
         auto_install: install missing packages needed to create the object
 
     .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
-    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
-    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
-    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     Returns:
         model

--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -53,14 +53,18 @@ def load(
             onnxruntime chooses the number of threads
         session_options: :class:`onnxruntime.SessionOptions`
             to use for inference.
-            If ``None`` the default options are used and the number of
-            threads for running inference on cpu is determined
-            by ``num_workers``. Otherwise, the provided options are used
+            If ``None`` the default options are used
+            and the number of threads
+            for running inference on cpu
+            is determined by ``num_workers``.
+            Otherwise,
+            the provided options are used
             and the ``session_options`` properties
             :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
             and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored
+            for inference on cpu
+            and ``num_workers`` is ignored
         auto_install: install missing packages needed to create the object
 
     .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -61,7 +61,7 @@ class Model(audobject.Object):
             and the ``session_options`` properties
             inter_op_num_threads_ and intra_op_num_threads_
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored.
+            for inference on cpu and ``num_workers`` is ignored
 
     Examples:
         >>> import audiofile

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -49,7 +49,7 @@ class Model(audobject.Object):
         transform: callable object or a dictionary of callable objects
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
-            or a (list of) provider(s)_
+            or a (list of) `provider(s)`_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
@@ -96,7 +96,7 @@ class Model(audobject.Object):
         ... ).round(1)
         array([-195.1,   73.3], dtype=float32)
 
-    .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
+    .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
     .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
     .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -52,7 +52,16 @@ class Model(audobject.Object):
             or a (list of) provider(s)_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
-            If ``None`` onnxruntime chooses the number of threads
+            If ``None`` and ``session_options`` is ``None``,
+            onnxruntime chooses the number of threads
+        session_options: onnxruntime.SessionOptions_ to use for inference.
+            If ``None`` the default options are used and the number of
+            threads for running inference on cpu is determined
+            by ``num_workers``. Otherwise, the provided options are used
+            and the ``session_options`` properties
+            inter_op_num_threads_ and intra_op_num_threads_
+            determine the number of threads
+            for inference on cpu and ``num_workers`` is ignored.
 
     Examples:
         >>> import audiofile
@@ -88,6 +97,9 @@ class Model(audobject.Object):
         array([-195.1,   73.3], dtype=float32)
 
     .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
+    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
+    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
+    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     """
     @audobject.init_decorator(
@@ -101,6 +113,7 @@ class Model(audobject.Object):
         hide=[
             'device',
             'num_workers',
+            'session_options',
         ],
     )
     def __init__(
@@ -111,6 +124,9 @@ class Model(audobject.Object):
             transform: Transform = None,
             device: Device = 'cpu',
             num_workers: typing.Optional[int] = 1,
+            session_options: typing.Optional[
+                onnxruntime.SessionOptions
+            ] = None,
     ):
         # keep original arguments to store them
         # when object is serialized
@@ -122,10 +138,11 @@ class Model(audobject.Object):
         self.path = audeer.path(path) if isinstance(path, str) else None
         r"""Model path"""
 
-        session_options = onnxruntime.SessionOptions()
-        if num_workers is not None:
-            session_options.inter_op_num_threads = num_workers
-            session_options.intra_op_num_threads = num_workers
+        if session_options is None:
+            session_options = onnxruntime.SessionOptions()
+            if num_workers is not None:
+                session_options.inter_op_num_threads = num_workers
+                session_options.intra_op_num_threads = num_workers
 
         providers = device_to_providers(device)
         self.sess = onnxruntime.InferenceSession(

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -56,14 +56,18 @@ class Model(audobject.Object):
             onnxruntime chooses the number of threads
         session_options: :class:`onnxruntime.SessionOptions`
             to use for inference.
-            If ``None`` the default options are used and the number of
-            threads for running inference on cpu is determined
-            by ``num_workers``. Otherwise, the provided options are used
+            If ``None`` the default options are used
+            and the number of threads
+            for running inference on cpu
+            is determined by ``num_workers``.
+            Otherwise,
+            the provided options are used
             and the ``session_options`` properties
             :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
             and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored
+            for inference on cpu
+            and ``num_workers`` is ignored
 
     Examples:
         >>> import audiofile

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -54,12 +54,14 @@ class Model(audobject.Object):
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
             onnxruntime chooses the number of threads
-        session_options: onnxruntime.SessionOptions_ to use for inference.
+        session_options: :class:`onnxruntime.SessionOptions`
+            to use for inference.
             If ``None`` the default options are used and the number of
             threads for running inference on cpu is determined
             by ``num_workers``. Otherwise, the provided options are used
             and the ``session_options`` properties
-            inter_op_num_threads_ and intra_op_num_threads_
+            :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
+            and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
             for inference on cpu and ``num_workers`` is ignored
 
@@ -97,9 +99,6 @@ class Model(audobject.Object):
         array([-195.1,   73.3], dtype=float32)
 
     .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
-    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
-    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
-    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     """
     @audobject.init_decorator(

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -45,14 +45,18 @@ def create_model(
             onnxruntime chooses the number of threads
         session_options: :class:`onnxruntime.SessionOptions`
             to use for inference.
-            If ``None`` the default options are used and the number of
-            threads for running inference on cpu is determined
-            by ``num_workers``. Otherwise, the provided options are used
+            If ``None`` the default options are used
+            and the number of threads
+            for running inference on cpu
+            is determined by ``num_workers``.
+            Otherwise,
+            the provided options are used
             and the ``session_options`` properties
             :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
             and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored
+            for inference on cpu
+            and ``num_workers`` is ignored
 
     Returns:
         model object

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -2,6 +2,7 @@ import typing
 
 import numpy as np  # noqa: F401, needed for doctest
 import onnx
+import onnxruntime
 
 from audonnx.core.function import Function
 from audonnx.core.model import Model
@@ -16,6 +17,7 @@ def create_model(
         opset_version: int = 14,
         device: Device = 'cpu',
         num_workers: typing.Optional[int] = 1,
+        session_options: typing.Optional[onnxruntime.SessionOptions] = None,
 ) -> Model:
     r"""Create test model.
 
@@ -39,7 +41,16 @@ def create_model(
             or a (list of) provider(s)_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
-            If ``None`` onnxruntime chooses the number of threads
+            If ``None`` and ``session_options`` is ``None``,
+            onnxruntime chooses the number of threads
+        session_options: onnxruntime.SessionOptions_ to use for inference.
+            If ``None`` the default options are used and the number of
+            threads for running inference on cpu is determined
+            by ``num_workers``. Otherwise, the provided options are used
+            and the ``session_options`` properties
+            inter_op_num_threads_ and intra_op_num_threads_
+            determine the number of threads
+            for inference on cpu and ``num_workers`` is ignored.
 
     Returns:
         model object
@@ -75,6 +86,10 @@ def create_model(
                 [0., 0.]]], dtype=float32)}
 
     .. _`supported data types`: https://onnxruntime.ai/docs/reference/operators/custom-python-operator.html#supported-data-types
+    .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
+    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
+    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
+    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     """  # noqa: E501
     # create graph
@@ -104,6 +119,7 @@ def create_model(
         transform=transform,
         device=device,
         num_workers=num_workers,
+        session_options=session_options,
     )
 
     return model

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -38,7 +38,7 @@ def create_model(
         opset_version: opset version
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
-            or a (list of) provider(s)_
+            or a (list of) `provider(s)`_
         num_workers: number of threads for running
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
@@ -86,7 +86,7 @@ def create_model(
                 [0., 0.]]], dtype=float32)}
 
     .. _`supported data types`: https://onnxruntime.ai/docs/reference/operators/custom-python-operator.html#supported-data-types
-    .. _provider(s): https://onnxruntime.ai/docs/execution-providers/
+    .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
     .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
     .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
     .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -43,14 +43,16 @@ def create_model(
             onnxruntime inference on cpu.
             If ``None`` and ``session_options`` is ``None``,
             onnxruntime chooses the number of threads
-        session_options: onnxruntime.SessionOptions_ to use for inference.
+        session_options: :class:`onnxruntime.SessionOptions`
+            to use for inference.
             If ``None`` the default options are used and the number of
             threads for running inference on cpu is determined
             by ``num_workers``. Otherwise, the provided options are used
             and the ``session_options`` properties
-            inter_op_num_threads_ and intra_op_num_threads_
+            :attr:`~onnxruntime.SessionOptions.inter_op_num_threads`
+            and :attr:`~onnxruntime.SessionOptions.intra_op_num_threads`
             determine the number of threads
-            for inference on cpu and ``num_workers`` is ignored.
+            for inference on cpu and ``num_workers`` is ignored
 
     Returns:
         model object
@@ -87,9 +89,6 @@ def create_model(
 
     .. _`supported data types`: https://onnxruntime.ai/docs/reference/operators/custom-python-operator.html#supported-data-types
     .. _`provider(s)`: https://onnxruntime.ai/docs/execution-providers/
-    .. _onnxruntime.SessionOptions: https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions
-    .. _inter_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.inter_op_num_threads
-    .. _intra_op_num_threads: https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.intra_op_num_threads
 
     """  # noqa: E501
     # create graph

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ copybutton_prompt_is_regexp = True
 intersphinx_mapping = {
     'audobject': ('https://audeering.github.io/audobject/', None),
     'python': ('https://docs.python.org/3/', None),
+    'onnxruntime': ('https://onnxruntime.ai/docs/api/python/', None),
     'opensmile': ('https://audeering.github.io/opensmile-python/', None),
     'torch': ('https://pytorch.org/docs/stable/', None),
 }

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 import numpy as np
+import onnxruntime
 import pytest
 
 import audeer
@@ -230,9 +231,21 @@ def test_call_concat(model, outputs, expected):
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda:0'])
 @pytest.mark.parametrize('num_workers', [None, 1, 2])
-def test_call_num_workers(device, num_workers):
+@pytest.mark.parametrize(
+    'session_options',
+    [
+        None,
+        onnxruntime.SessionOptions(),
+    ]
+)
+def test_call_num_workers_session_options(
+    device, num_workers, session_options
+):
     model = audonnx.testing.create_model(
-        [[2]], device=device, num_workers=num_workers
+        [[2]],
+        device=device,
+        num_workers=num_workers,
+        session_options=session_options,
     )
     y = model(
         pytest.SIGNAL,


### PR DESCRIPTION
Closes #82 

This adds the argument `session_options` to `audonnx.Model` and `audonnx.load()`. The `session_options` argument takes precedence over the `num_workers` argument. This means that if `session_options` is not `None`, you don't have to worry about also setting `num_workers` to the intended value. And if you choose to set `num_workers` instead, `session_options` defaults to `None` and doesn't need to be adjusted either.

Additionally, the `session_options` argument is added to `audonnx.testing.create_model()`, and the link(s) for `provider(s)` in the docstring of `audonnx.Model`, `audonnx.load()`, and `audonnx.testing.create_model()` were fixed/adjusted.

![image](https://github.com/audeering/audonnx/assets/99745980/be10a75b-c8a9-4220-a23e-81c2bdb5b802)

![image](https://github.com/audeering/audonnx/assets/99745980/e302cd64-544a-416e-b222-a45e7a026bcd)

![image](https://github.com/audeering/audonnx/assets/99745980/345cb652-8378-44f2-a1f2-16d3c7e22602)


