### PR TITLE
DOC: add missing changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Version 0.6.4 (2023-11-10)
 
 * Added: pre-processing step in the documentation
   on how to quantize an ONNX model
+* Added: support for Python 3.11
 * Removed: support for Python 3.7
 
 


### PR DESCRIPTION
Add missing Python 3.11 support to changelog for version 0.6.4.

![image](https://github.com/audeering/audonnx/assets/173624/d52dd5c4-901f-483a-a0ee-aa786c60fd14)
