### PR TITLE
Add IR version as argument to model creation

### DIFF
--- a/audonnx/core/function.py
+++ b/audonnx/core/function.py
@@ -18,7 +18,7 @@ class Function(audobject.Object):
         >>> object
         {'$audonnx.core.function.Function': {'func': 'lambda x, sr: x.mean()', 'func_args': {}}}
         >>> object(np.array([1, 2, 3]), 10)
-        2.0
+        np.float64(2.0)
 
     """  # noqa: E501
     @audobject.init_decorator(

--- a/audonnx/core/function.py
+++ b/audonnx/core/function.py
@@ -14,11 +14,11 @@ class Function(audobject.Object):
         func_args: additional arguments that will be passed to the function
 
     Examples:
-        >>> object = Function(lambda x, sr: x.mean())
+        >>> object = Function(lambda x, sr: float(x.mean()))
         >>> object
-        {'$audonnx.core.function.Function': {'func': 'lambda x, sr: x.mean()', 'func_args': {}}}
+        {'$audonnx.core.function.Function': {'func': 'lambda x, sr: float(x.mean())', 'func_args': {}}}
         >>> object(np.array([1, 2, 3]), 10)
-        np.float64(2.0)
+        2.0
 
     """  # noqa: E501
     @audobject.init_decorator(

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -15,7 +15,7 @@ def create_model(
         value: float = 0.,
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
-        ir_version: int = 10,
+        ir_version: int = 7,
         device: Device = 'cpu',
         num_workers: typing.Optional[int] = 1,
         session_options: typing.Optional[onnxruntime.SessionOptions] = None,
@@ -136,7 +136,7 @@ def create_model_proto(
         *,
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
-        ir_version: int = 10,
+        ir_version: int = 7,
 ) -> onnx.ModelProto:
     r"""Create test ONNX proto object.
 
@@ -164,7 +164,7 @@ def create_model_proto(
 
     Examples:
         >>> create_model_proto([[2]])
-        ir_version: 10
+        ir_version: 7
         producer_name: "test"
         graph {
           node {

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -15,6 +15,7 @@ def create_model(
         value: float = 0.,
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
+        ir_version: int = 10,
         device: Device = 'cpu',
         num_workers: typing.Optional[int] = 1,
         session_options: typing.Optional[onnxruntime.SessionOptions] = None,
@@ -36,6 +37,7 @@ def create_model(
         value: fill value
         dtype: data type, see `supported data types`_
         opset_version: opset version
+        ir_version: ir version
         device: set device
             (``'cpu'``, ``'cuda'``, or ``'cuda:<id>'``)
             or a (list of) `provider(s)`_
@@ -101,6 +103,7 @@ def create_model(
         shapes,
         dtype=dtype,
         opset_version=opset_version,
+        ir_version=ir_version
     )
 
     # create transform objects
@@ -133,6 +136,7 @@ def create_model_proto(
         *,
         dtype: int = onnx.TensorProto.FLOAT,
         opset_version: int = 14,
+        ir_version: int = 10,
 ) -> onnx.ModelProto:
     r"""Create test ONNX proto object.
 
@@ -153,16 +157,14 @@ def create_model_proto(
             input and output nodes of the model graph
         dtype: data type, see `supported data types`_
         opset_version: opset version
+        ir_version: ir version
 
     Returns:
         ONNX object
 
     Examples:
         >>> create_model_proto([[2]])
-        ir_version: 9
-        opset_import {
-          version: 14
-        }
+        ir_version: 10
         producer_name: "test"
         graph {
           node {
@@ -197,6 +199,9 @@ def create_model_proto(
               }
             }
           }
+        }
+        opset_import {
+          version: 14
         }
         <BLANKLINE>
 
@@ -244,6 +249,7 @@ def create_model_proto(
 
     model = onnx.helper.make_model(graph, producer_name='test')
     model.opset_import[0].version = opset_version
+    model.ir_version = ir_version
     onnx.checker.check_model(model)
 
     return model


### PR DESCRIPTION
This adds `ir_version` as a keyword argument to `audonnx.testing.create_model()` and `audonnx.testing.create_model_proto()`.

With some recent changes to `onnx`, I ran into issues when using `audonnx.testing.create_model()`.
The problem seems to be that the new IR version 11 is selected by default when creating a model, although it doesn't look like any [opset versions are supported for that yet](https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support).

I retriggered the test pipeline in https://github.com/audeering/audonnx/pull/90 , which fails.

By adding the `ir_version` argument with default value `7`, a usable test model is created again.

## Summary by Sourcery

Allow specifying the ONNX IR version for test model creation by introducing an ir_version parameter (defaulting to 7) and update related documentation examples accordingly

New Features:
- Add ir_version keyword argument to create_model() and create_model_proto(), defaulting to 7, and apply it to the generated ONNX model

Documentation:
- Update create_model_proto doc examples to reflect the new default ir_version and correct opset_import ordering
- Adjust Function class documentation example to explicitly cast .mean() result to float