### PR TITLE
CI: update Actions, use Ubtunu-latest, extra doc

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Documentation
 
 on:
   push:
@@ -12,13 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ '3.10' ]
-        include:
-          - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
-            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v4
@@ -28,11 +23,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Prepare Ubuntu
+    - name: Ubuntu - install libsndfile
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox
-      if: matrix.os == 'ubuntu-latest'
 
     - name: Install dependencies
       run: |
@@ -41,13 +35,8 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Test with pytest
-      run: |
-        python -m pytest
+    - name: Test building documentation
+      run: python -m sphinx docs/ docs/_build/ -b html -W
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-      if: matrix.os == 'ubuntu-latest'
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,12 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -53,7 +53,7 @@ jobs:
         python -m sphinx docs/ docs/_build/ -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
@@ -75,7 +75,7 @@ jobs:
 
     - name: Create release on Github
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Have a look at the installation_ and usage_ instructions.
 .. _scikit-learn: https://scikit-learn.org
 .. _TensorFlow: https://www.tensorflow.org
 .. _Torch: https://pytorch.org/
-.. _installation: https://audeering.github.io/audonnx/install.html
+.. _installation: https://audeering.github.io/audonnx/installation.html
 .. _usage: https://audeering.github.io/audonnx/usage.html
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -511,10 +511,10 @@ In that case do:
 
 
 .. _audformat: https://audeering.github.io/audformat/
-.. _audinterface: http://tools.pp.audeering.com/audinterface/
-.. _audobject: http://tools.pp.audeering.com/audobject/
+.. _audinterface: https://audeering.github.io/audinterface/
+.. _audobject: https://audeering.github.io/audobject/
 .. _librosa: https://librosa.org/doc/main/index.html
-.. _MobilenetV2 example: https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification/cpu/ReadMe.md#onnx-runtime-quantization-example
+.. _MobilenetV2 example: https://github.com/microsoft/onnxruntime-inference-examples/blob/main/quantization/image_classification/cpu/ReadMe.md
 .. _ONNX: https://onnx.ai/
 .. _OpenSMILE: https://github.com/audeering/opensmile-python
 .. _table: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements


### PR DESCRIPTION
Modernize Ci pipeline by using actual Action plugin versions, using Ubuntu-latest, and adding an extra doc Action.

## Summary by Sourcery

Modernize the CI pipelines by updating runner OS and GitHub Action versions, streamlining test workflows, and adding a dedicated documentation build and link-check workflow.

CI:
- Upgrade core Actions (actions/checkout, setup-python, codecov, gh-pages, action-gh-release) to their latest major versions
- Standardize all workflows to run on ubuntu-latest and remove Ubuntu-20.04 entries
- Remove in-test documentation build and adjust coverage and install steps to target ubuntu-latest only
- Introduce a new CI workflow that builds and link-checks Sphinx documentation on main branch pushes and pull requests