### PR TITLE
TST: require audobject>=0.7.12

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,5 @@
 opensmile >=2.3.0
-# Avoid pip error on Python 3.7,
-# compare https://github.com/audeering/audonnx/runs/5737150095
-audobject >=0.7.1
+audobject >=0.7.12
 pytest
 pytest-doctestplus
 pytest-console-scripts


### PR DESCRIPTION
Closes https://github.com/audeering/audonnx/issues/89

The Python 3.11 string representation error of lambda functions is solved in `audobject` 0.7.12.