### PR TITLE
Depend on onnxruntime>=1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ requires-python = '>=3.9'
 dependencies = [
     'audobject >=0.7.2',
     'onnx',
-    'onnxruntime >=1.8.0,<=1.19.2 ; python_version == "3.9"',
-    'onnxruntime >=1.8.0; python_version >= "3.10"',
+    'onnxruntime >=1.12.0,<=1.19.2 ; python_version == "3.9"',
+    'onnxruntime >=1.12.0; python_version >= "3.10"',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ requires-python = '>=3.9'
 dependencies = [
     'audobject >=0.7.2',
     'onnx',
-    'onnxruntime >=1.8.0,<=1.19.2 ; python_version == "3.9"',
-    'onnxruntime >=1.8.0; python_version >= "3.10"',
+    'onnxruntime >=1.12.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ requires-python = '>=3.9'
 dependencies = [
     'audobject >=0.7.2',
     'onnx',
-    'onnxruntime >=1.12.0',
+    'onnxruntime >=1.8.0,<=1.19.2 ; python_version == "3.9"',
+    'onnxruntime >=1.8.0; python_version >= "3.10"',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Require `onnxruntime>=1.12.0` so we can drop support for Python 3.9 in a next step.