### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,17 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'audobject >=0.7.2',
     'onnx',
-    'onnxruntime >=1.12.0,<=1.19.2 ; python_version == "3.9"',
-    'onnxruntime >=1.12.0; python_version >= "3.10"',
+    'onnxruntime >=1.12.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
To make dependency handling easier and less error prone we remove support for Python 3.9.