### PR TITLE
Update syntax to Python>=3.10

### DIFF
--- a/audonnx/core/api.py
+++ b/audonnx/core/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import os
 

--- a/audonnx/core/function.py
+++ b/audonnx/core/function.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 
 import numpy as np

--- a/audonnx/core/model.py
+++ b/audonnx/core/model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import os
 

--- a/audonnx/core/node.py
+++ b/audonnx/core/node.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 
 import numpy as np

--- a/audonnx/core/ort.py
+++ b/audonnx/core/ort.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import re
 

--- a/audonnx/core/testing.py
+++ b/audonnx/core/testing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 
 import numpy as np  # noqa: F401, needed for doctest

--- a/audonnx/core/typing.py
+++ b/audonnx/core/typing.py
@@ -1,31 +1,10 @@
 from collections.abc import Callable
 from collections.abc import Sequence
-from typing import Optional
-from typing import Union
 
 import numpy as np
 
 
-Device = Union[
-    str,
-    tuple[str, dict],
-    Sequence[Union[str, tuple[str, dict]]],
-]
-
-
-Labels = Union[
-    Sequence[str],
-    dict[str, Optional[Sequence[str]]],
-]
-
-
-Transform = Union[
-    Callable[
-        [np.ndarray, int],
-        np.ndarray,
-    ],
-    dict[
-        str,
-        Optional[Callable[[np.ndarray, int], np.ndarray]],
-    ],
-]
+Device = str | tuple[str, dict] | Sequence[str | tuple[str, dict]]
+Labels = Sequence[str] | dict[str, Sequence[str] | None]
+_Transform = Callable[[np.ndarray, int], np.ndarray]
+Transform = _Transform | dict[str, _Transform]


### PR DESCRIPTION
Update syntax to Python >=3.10:

* remove `typing` module and from future imports

## Summary by Sourcery

Upgrade the codebase to Python 3.10+ by removing the typing module and future annotations imports and adopting PEP 604 union types for all type aliases.

Enhancements:
- Bump the minimum Python requirement to 3.10 and drop all __future__ annotations imports
- Remove usage of the typing module and replace Union types with built-in '|' operator and standard library generics for Device, Labels, and Transform type aliases