### PR TITLE
Fix DeprecationWarning for documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,6 +5,8 @@ Usage
     :hide-code:
     :hide-output:
 
+    import warnings
+
     import pandas as pd
 
 
@@ -19,7 +21,8 @@ Usage
         return self.to_frame(index=False)._repr_html_()
     setattr(pd.Index, '_repr_html_', index_to_html)
 
-    # Comment to trigger pipeline
+    # Ignore warning for using legacy torch to onnx export
+    warnings.simplefilter(action="ignore", category=DeprecationWarning)
 
 
 :mod:`audonnx` offers a simple interface

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -143,6 +143,7 @@ And we assign meaningful names to the nodes.
         output_names=['gender'],  # assign custom name to output node
         dynamic_axes={'feature': {1: 'time'}},  # dynamic size
         opset_version=12,
+        dynamo=False,
     )
 
 From the exported model file
@@ -421,6 +422,7 @@ we do not set a transform for it.
             'feature': {1: 'time'},
         },
         opset_version=12,
+        dynamo=False,
     )
 
     onnx_model_7 = audonnx.Model(

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,6 +19,8 @@ Usage
         return self.to_frame(index=False)._repr_html_()
     setattr(pd.Index, '_repr_html_', index_to_html)
 
+    # Comment to trigger pipeline
+
 
 :mod:`audonnx` offers a simple interface
 to load and use models in ONNX_ format.


### PR DESCRIPTION
This suppresses the `DeprecationWarning` when building the documentation, and ensures that the legacy `torch` export will be used also for future `torch` versions

With newer torch versions, the default export to onnx will be [TorchDynamo-based](https://docs.pytorch.org/docs/stable/onnx_dynamo.html), meaning that the default value for the dynamo argument will be `True`. So we explicitely set the argument to `False`.

## Summary by Sourcery

Suppress DeprecationWarning in documentation builds by filtering warnings and updating torch.onnx.export examples to explicitly pass dynamo=False

Documentation:
- Add a warning filter in usage.rst to suppress DeprecationWarning when building docs
- Update torch.onnx.export examples in the documentation to include the dynamo=False argument